### PR TITLE
Configure Dependency Injection and Register Core Services as Single…

### DIFF
--- a/PlugHub.Shared/Extensions/TypeExtensions.cs
+++ b/PlugHub.Shared/Extensions/TypeExtensions.cs
@@ -1,0 +1,19 @@
+﻿using System.Text.Json;
+
+namespace PlugHub.Shared.Extensions
+{
+    public static class TypeExtensions
+    {
+        /// <summary>
+        /// Serializes a new instance of the given type (using its parameterless constructor) to JSON.
+        /// </summary>
+        public static string SerializeToJson(this Type type, JsonSerializerOptions? options = null)
+        {
+            if (type.GetConstructor(Type.EmptyTypes) == null)
+                throw new InvalidOperationException($"{type.Name} requires a parameterless constructor for default initialization");
+            object instance = Activator.CreateInstance(type)!;
+            return JsonSerializer.Serialize(instance, options ?? new JsonSerializerOptions { WriteIndented = true });
+        }
+    }
+
+}

--- a/PlugHub.Shared/Interfaces/Services/IConfigAccessor.cs
+++ b/PlugHub.Shared/Interfaces/Services/IConfigAccessor.cs
@@ -1,0 +1,67 @@
+﻿using PlugHub.Shared.Models;
+
+namespace PlugHub.Shared.Interfaces.Services
+{
+    /// <summary>
+    /// Provides an entry point for accessing configuration sections by type.
+    /// </summary>
+    public interface IConfigAccessor
+    {
+        /// <summary>
+        /// Gets a strongly-typed configuration accessor for the specified configuration type.
+        /// </summary>
+        /// <typeparam name="TConfig">The configuration section type.</typeparam>
+        /// <returns>
+        /// An <see cref="IConfigAccessorFor{TConfig}"/> for accessing configuration values of <typeparamref name="TConfig"/>.
+        /// </returns>
+        IConfigAccessorFor<TConfig> For<TConfig>() where TConfig : class;
+    }
+
+    /// <summary>
+    /// Provides methods to get, set, and save configuration values for a specific configuration section.
+    /// </summary>
+    /// <typeparam name="TConfig">The configuration section type.</typeparam>
+    public interface IConfigAccessorFor<TConfig> where TConfig : class
+    {
+        /// <summary>
+        /// Gets a configuration value by key and converts it to the specified type.
+        /// </summary>
+        /// <typeparam name="T">The expected type of the configuration value.</typeparam>
+        /// <param name="key">The key identifying the configuration value.</param>
+        /// <returns>
+        /// The configuration value converted to type <typeparamref name="T"/>.
+        /// </returns>
+        T Get<T>(string key);
+
+        /// <summary>
+        /// Sets a configuration value for the specified key.
+        /// </summary>
+        /// <typeparam name="T">The type of the value being set.</typeparam>
+        /// <param name="key">The key identifying the configuration value.</param>
+        /// <param name="value">The value to set.</param>
+        void Set<T>(string key, T value);
+
+        /// <summary>
+        /// Persists any changes made to the configuration section.
+        /// </summary>
+        Task SaveAsync();
+
+
+        /// <summary>
+        /// Saves all property values from the provided <paramref name="config"/> instance to persistent storage.
+        /// Each property is applied using the config service's merge logic (removing user values that match base, etc.).
+        /// This method ensures that only changed or user-specific values are persisted, maintaining minimal user config footprint.
+        /// </summary>
+        /// <param name="config">The configuration instance to persist.</param>
+        /// <returns>A task that completes when the save operation finishes.</returns>
+        TConfig Get();
+
+        /// <summary>
+        /// Retrieves a fully populated instance of the configuration class <typeparamref name="TConfig"/>.
+        /// This method merges base and user settings according to PlugHub config rules, ensuring the returned object
+        /// reflects the effective configuration for the current accessor's context and permissions.
+        /// </summary>
+        /// <returns>The current configuration instance for <typeparamref name="TConfig"/>.</returns>
+        Task SaveAsync(TConfig config);
+    }
+}

--- a/PlugHub.Shared/Interfaces/Services/IConfigService.cs
+++ b/PlugHub.Shared/Interfaces/Services/IConfigService.cs
@@ -1,0 +1,249 @@
+﻿using Microsoft.Extensions.Configuration;
+using PlugHub.Shared.Models;
+
+namespace PlugHub.Shared.Interfaces.Services
+{
+    /// <summary>
+    /// Event arguments for when a configuration file is reloaded in the <see cref="ConfigService"/>.
+    /// Provides the type of the configuration that was reloaded.
+    /// </summary>
+    /// <param name="configType">The configuration type that was reloaded.</param>
+    public class ConfigServiceConfigReloadedEventArgs(Type configType) : EventArgs
+    {
+        /// <summary>
+        /// Gets the configuration type that was reloaded.
+        /// </summary>
+        public Type ConfigType { get; } = configType;
+    }
+
+    /// <summary>
+    /// Event arguments for when an application-level setting changes in the <see cref="ConfigService"/>.
+    /// Provides the key and both the old and new values of the setting.
+    /// </summary>
+    /// <param name="key">The key of the setting that changed.</param>
+    /// <param name="oldValue">The previous value of the setting.</param>
+    /// <param name="newValue">The new value of the setting.</param>
+    public class ConfigServiceAppSettingChangeEventArgs(string key, object? oldValue, object? newValue) : EventArgs
+    {
+        /// <summary>
+        /// Gets the key of the application setting that changed.
+        /// </summary>
+        public string Key { get; } = key;
+
+        /// <summary>
+        /// Gets the previous value of the setting.
+        /// </summary>
+        public object? OldValue { get; } = oldValue;
+
+        /// <summary>
+        /// Gets the new value of the setting.
+        /// </summary>
+        public object? NewValue { get; } = newValue;
+    }
+
+    /// <summary>
+    /// Event arguments for when a plugin or user setting changes in the <see cref="ConfigService"/>.
+    /// Provides the configuration type, key, and both the old and new values of the setting.
+    /// </summary>
+    /// <param name="configType">The configuration type where the setting changed.</param>
+    /// <param name="key">The key of the setting that changed.</param>
+    /// <param name="oldValue">The previous value of the setting.</param>
+    /// <param name="newValue">The new value of the setting.</param>
+    public class ConfigServiceSettingChangeEventArgs(Type configType, string key, object? oldValue, object? newValue) : EventArgs
+    {
+        /// <summary>
+        /// Gets the configuration type where the setting changed.
+        /// </summary>
+        public Type ConfigType { get; } = configType;
+
+        /// <summary>
+        /// Gets the key of the setting that changed.
+        /// </summary>
+        public string Key { get; } = key;
+
+        /// <summary>
+        /// Gets the previous value of the setting.
+        /// </summary>
+        public object? OldValue { get; } = oldValue;
+
+        /// <summary>
+        /// Gets the new value of the setting.
+        /// </summary>
+        public object? NewValue { get; } = newValue;
+    }
+
+
+    /// <summary>
+    /// Provides methods for managing application and plugin configuration settings.
+    /// </summary>
+    public interface IConfigService
+    {
+        /// <summary>
+        /// Creates an <see cref="IConfigAccessor"/> for a single configuration type, 
+        /// using the specified read and write tokens for access control.
+        /// This accessor provides type-safe get/set/save operations for the registered config type.
+        /// </summary>
+        /// <param name="configTypes">The configuration type to access.</param>
+        /// <param name="readToken">An optional token for read access; defaults to public if not specified.</param>
+        /// <param name="writeToken">An optional token for write access; defaults to the read token if not specified.</param>
+        /// <returns>An <see cref="IConfigAccessor"/> scoped to the specified type and tokens.</returns>
+        public IConfigAccessor CreateAccessor(Type configTypes, Token? readToken = null, Token? writeToken = null);
+
+        /// <summary>
+        /// Creates an <see cref="IConfigAccessor"/> for multiple configuration types,
+        /// using the specified read and write tokens for access control.
+        /// This accessor enables batch or multi-type config operations with unified token validation.
+        /// </summary>
+        /// <param name="configTypes">The configuration types to access.</param>
+        /// <param name="readToken">An optional token for read access; defaults to public if not specified.</param>
+        /// <param name="writeToken">An optional token for write access; defaults to the read token if not specified.</param>
+        /// <returns>An <see cref="IConfigAccessor"/> scoped to the specified types and tokens.</returns>
+        public IConfigAccessor CreateAccessor(IEnumerable<Type> configTypes, Token? readToken = null, Token? writeTOken = null);
+
+
+        /// <summary>
+        /// Occurs when the application configuration file is reloaded from disk (for example, due to an external file change).
+        /// </summary>
+        public event EventHandler<EventArgs>? AppConfigReloaded;
+
+        /// <summary>
+        /// Occurs when a plugin configuration file is reloaded from disk (for example, due to an external file change).
+        /// </summary>
+        public event EventHandler<ConfigServiceConfigReloadedEventArgs>? ConfigReloaded;
+
+        /// <summary>
+        /// Occurs when an application-wide configuration value is changed via <see cref="SetAppSetting{T}(string, T)"/>.
+        /// </summary>
+        public event EventHandler<ConfigServiceAppSettingChangeEventArgs> AppSettingChanged;
+
+        /// <summary>
+        /// Occurs when a plugin-specific configuration value is changed via <see cref="SetSetting{T}(Type, string, T, bool)"/>.
+        /// </summary>
+        public event EventHandler<ConfigServiceSettingChangeEventArgs> SettingChanged;
+
+
+        /// <summary>
+        /// Registers a single plugin configuration type.
+        /// </summary>
+        /// <param name="configType">The type representing the plugin configuration.</param>
+        public void RegisterConfig(Type configType, Token? readToken = null, Token? writeToken = null);
+
+        /// <summary>
+        /// Registers plugin configuration types.
+        /// </summary>
+        /// <param name="configTypes">The types representing plugin configurations.</param>
+        public void RegisterConfigs(IEnumerable<Type> configTypes, Token? readToken = null, Token? writeToken = null);
+
+
+        /// <summary>
+        /// Gets the raw contents of the base configuration file for the specified configuration type.
+        /// </summary>
+        /// <param name="configType">The type of the configuration section.</param>
+        /// <param name="token">
+        /// (Optional) The security token used for access validation. If not provided, <see cref="Token.Public"/> is used.
+        /// </param>
+        /// <returns>The contents of the base configuration file as a string.</returns>
+        public string GetBaseConfigFileContents(Type configType, Token? token = null);
+
+        /// <summary>
+        /// Gets the raw contents of the base configuration file for the specified generic configuration type.
+        /// </summary>
+        /// <typeparam name="TConfig">The configuration section type.</typeparam>
+        /// <param name="token">
+        /// (Optional) The security token used for access validation. If not provided, <see cref="Token.Public"/> is used.
+        /// </param>
+        /// <returns>The contents of the base configuration file as a string.</returns>
+        public string GetBaseConfigFileContents<TConfig>(Token? token = null) where TConfig : class;
+
+
+        /// <summary>
+        /// Asynchronously saves the provided contents to the base configuration file for the specified configuration type.
+        /// </summary>
+        /// <param name="configType">The type of the configuration section.</param>
+        /// <param name="contents">The raw string contents to write to the base configuration file.</param>
+        /// <param name="token">
+        /// (Optional) The security token used for access validation. If not provided, <see cref="Token.Public"/> is used.
+        /// </param>
+        /// <returns>A task representing the asynchronous save operation.</returns>
+        public Task SaveBaseConfigFileContentsAsync(Type configType, string contents, Token? token = null);
+
+        /// <summary>
+        /// Asynchronously saves the provided contents to the base configuration file for the specified generic configuration type.
+        /// </summary>
+        /// <typeparam name="TConfig">The configuration section type.</typeparam>
+        /// <param name="contents">The raw string contents to write to the base configuration file.</param>
+        /// <param name="token">
+        /// (Optional) The security token used for access validation. If not provided, <see cref="Token.Public"/> is used.
+        /// </param>
+        /// <returns>A task representing the asynchronous save operation.</returns>
+        public Task SaveBaseConfigFileContentsAsync<TConfig>(string contents, Token? token = null) where TConfig : class;
+
+
+        /// <summary>
+        /// Retrieves a fully populated configuration instance of the specified type.
+        /// This method merges base and user settings according to PlugHub config rules,
+        /// returning an object that reflects the effective configuration state.
+        /// </summary>
+        /// <param name="configType">The Type of configuration class to retrieve</param>
+        /// <param name="token">Optional security token for access validation</param>
+        /// <returns>A populated instance of the requested configuration type</returns>
+        /// <exception cref="KeyNotFoundException">Thrown if configType is not registered</exception>
+        /// <exception cref="InvalidOperationException">Thrown if instance creation fails</exception>
+        public object GetConfigInstance(Type configType, Token? token = null);
+
+        /// <summary>
+        /// Persists property values from a configuration instance to storage.
+        /// Applies each property using the config service's merge logic, ensuring user values
+        /// are only stored when they differ from base values (minimal user config footprint).
+        /// </summary>
+        /// <param name="configType">The Type of configuration being updated</param>
+        /// <param name="updatedConfig">Instance containing new property values</param>
+        /// <param name="token">Optional security token for write validation</param>
+        /// <exception cref="ArgumentNullException">Thrown if updatedConfig is null</exception>
+        public void SaveConfigInstance(Type configType, object updatedConfig, Token? token = null);
+
+
+
+        /// <summary>
+        /// Gets a read-only <see cref="IConfiguration"/> representing the current environment variables and command-line arguments.
+        /// </summary>
+        /// <returns>
+        /// An <see cref="IConfiguration"/> instance containing environment and command-line settings. This object is read-only.
+        /// </returns>
+        public IConfiguration GetEnvConfig();
+
+        /// <summary>
+        /// Gets an application-wide setting by key.
+        /// </summary>
+        /// <typeparam name="T">The type of the setting value.</typeparam>
+        /// <param name="key">The setting key.</param>
+        /// <returns>The setting value.</returns>
+        public T GetAppSetting<T>(string key);
+
+
+        /// <summary>
+        /// Gets a plugin-specific setting by type and key.
+        /// </summary>
+        /// <typeparam name="T">The type of the setting value.</typeparam>
+        /// <param name="configType">The plugin configuration type.</param>
+        /// <param name="key">The setting key.</param>
+        /// <returns>The setting value.</returns>
+        public T GetSetting<T>(Type configType, string key, Token? token = null);
+
+        /// <summary>
+        /// Sets a plugin-specific setting by type and key.
+        /// </summary>
+        /// <typeparam name="T">The type of the setting value.</typeparam>
+        /// <param name="configType">The plugin configuration type.</param>
+        /// <param name="key">The setting key.</param>
+        /// <param name="value">The setting value.</param>
+        /// <param name="isBase">Indicates if this is a system-level setting.</param>
+        public void SetSetting<T>(Type configType, string key, T value, Token? token = null);
+
+        /// <summary>
+        /// Saves settings for a specific plugin.
+        /// </summary>
+        /// <param name="configType">The plugin configuration type.</param>
+        public Task SaveSettingsAsync(Type configType, Token? token = null);
+    }
+}

--- a/PlugHub.UnitTests/Services/ConfigAccessorTests.cs
+++ b/PlugHub.UnitTests/Services/ConfigAccessorTests.cs
@@ -1,0 +1,272 @@
+﻿using Microsoft.Extensions.Logging;
+using Moq;
+using PlugHub.Services;
+using PlugHub.Shared.Interfaces.Services;
+using PlugHub.Shared.Models;
+
+namespace PlugHub.UnitTests.Services
+{
+    [TestClass]
+    public class ConfigAccessorTests
+    {
+        private Mock<ILogger<ConfigService>>? loggerMock;
+        private ITokenService? tokenService;
+        private string? testConfigPath;
+        private ConfigService? configService;
+
+        // Test configuration classes
+        public class AlphaPluginConfig
+        {
+            public int FieldA { get; set; } = 50;
+            public bool FieldB { get; set; } = false;
+        }
+
+        public class BetaPluginConfig
+        {
+            public required string FieldA { get; set; } = "";
+            public int FieldB { get; set; } = 120;
+        }
+
+        [TestInitialize]
+        public void Setup()
+        {
+            Mock<ILogger<TokenService>> tokenLoggerMock = new Mock<ILogger<TokenService>>();
+            this.loggerMock = new Mock<ILogger<ConfigService>>();
+            this.tokenService = new TokenService(tokenLoggerMock.Object);
+            this.testConfigPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(this.testConfigPath);
+
+            this.configService = new ConfigService(
+                this.loggerMock.Object,
+                this.tokenService,
+                this.testConfigPath,
+                this.testConfigPath
+            );
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            if (this.testConfigPath != null && Directory.Exists(this.testConfigPath))
+                Directory.Delete(this.testConfigPath, true);
+        }
+
+        [TestMethod]
+        public void ConfigAccessorForRegisteredTypeReturnsAccessor()
+        {
+            // Arrange
+            Token token = this.tokenService!.CreateToken();
+            this.CreateConfigFile("AlphaPluginConfig.BaseSettings.json",
+                "{\"FieldA\": 100, \"FieldB\": true}");
+
+            this.configService!.RegisterConfigs([typeof(AlphaPluginConfig)]);
+
+            // Act
+            IConfigAccessor accessor = this.configService.CreateAccessor(typeof(AlphaPluginConfig), token);
+            IConfigAccessorFor<AlphaPluginConfig> typedAccessor = accessor.For<AlphaPluginConfig>();
+
+            // Assert
+            Assert.IsNotNull(typedAccessor);
+        }
+
+        [TestMethod]
+        public void ConfigAccessorGetValueReturnsCorrectValue()
+        {
+            // Arrange
+            Token token = this.tokenService!.CreateToken();
+            this.CreateConfigFile("AlphaPluginConfig.BaseSettings.json",
+                "{\"FieldA\": 100, \"FieldB\": true}");
+
+            this.configService!.RegisterConfigs([typeof(AlphaPluginConfig)]);
+            IConfigAccessor accessor = this.configService.CreateAccessor(typeof(AlphaPluginConfig), token);
+            IConfigAccessorFor<AlphaPluginConfig> typedAccessor = accessor.For<AlphaPluginConfig>();
+
+            // Act
+            int value = typedAccessor.Get<int>("FieldA");
+
+            // Assert
+            Assert.AreEqual(100, value);
+        }
+
+        [TestMethod]
+        public void ConfigAccessorSetValueUpdatesConfiguration()
+        {
+            if (this.configService == null)
+                return;
+
+            // Arrange
+            Token token = this.tokenService!.CreateToken();
+            this.CreateConfigFile("BetaPluginConfig.UserSettings.json",
+                "{\"FieldA\": \"test\", \"FieldB\": 200}");
+
+            IConfigAccessor accessor = this.configService.CreateAccessor(typeof(BetaPluginConfig), token);
+            IConfigAccessorFor<BetaPluginConfig> typedAccessor = accessor.For<BetaPluginConfig>();
+
+            // Act
+            typedAccessor.Set("FieldA", "updated");
+            string updatedValue = typedAccessor.Get<string>("FieldA");
+
+            // Assert
+            Assert.AreEqual("updated", updatedValue);
+        }
+
+        [TestMethod]
+        public async Task ConfigAccessorSavePersistsChangesAsync()
+        {
+            if (this.testConfigPath == null)
+                return;
+
+            // Arrange
+            Token token = this.tokenService!.CreateToken();
+            this.CreateConfigFile("BetaPluginConfig.UserSettings.json",
+                "{\"FieldA\": \"test\", \"FieldB\": 200}");
+
+            this.configService!.RegisterConfigs([typeof(BetaPluginConfig)]);
+            IConfigAccessor accessor = this.configService.CreateAccessor(typeof(BetaPluginConfig));
+            IConfigAccessorFor<BetaPluginConfig> typedAccessor = accessor.For<BetaPluginConfig>();
+
+            // Act
+            typedAccessor.Set("FieldA", "updated");
+            await typedAccessor.SaveAsync();  // Added await
+
+            // Assert
+            string filePath = Path.Combine(this.testConfigPath, "Config", "BetaPluginConfig.UserSettings.json");
+            string fileContent = File.ReadAllText(filePath);
+            Assert.IsTrue(fileContent.Contains("\"FieldA\":\"updated\""),
+                $"File content: {fileContent}");
+        }
+
+        [TestMethod]
+        public void RegisterConfig_WithAttackerToken_ThrowsWhenOverwriting()
+        {
+            // Arrange
+            Token ownerToken = tokenService!.CreateToken();
+            Token attackerToken = tokenService!.CreateToken();
+            CreateConfigFile("AlphaPluginConfig.BaseSettings.json", "{}");
+
+            // First registration (owner)
+            configService!.RegisterConfigs([typeof(AlphaPluginConfig)], ownerToken);
+
+            // Act & Assert
+            Assert.ThrowsException<UnauthorizedAccessException>(() =>
+                configService.RegisterConfigs([typeof(AlphaPluginConfig)], attackerToken));
+        }
+
+        [TestMethod]
+        public void ConfigAccessorForUnregisteredTypeThrowsException()
+        {
+            // Arrange
+            Token token = this.tokenService!.CreateToken();
+            IConfigAccessor accessor = this.configService!.CreateAccessor(typeof(AlphaPluginConfig), token);
+
+            // Act & Assert
+            Assert.ThrowsException<TypeAccessException>(() =>
+                accessor.For<BetaPluginConfig>());
+        }
+
+
+        [TestMethod]
+        public void ConfigAccessorGet_ReturnsCorrectInstance()
+        {
+            if (this.testConfigPath == null || this.configService == null)
+                return;
+
+            // Arrange
+            Token token = this.tokenService!.CreateToken();
+            this.CreateConfigFile("BetaPluginConfig.BaseSettings.json",
+                "{\"FieldA\":\"base-value\",\"FieldB\":500}");
+
+            this.configService.RegisterConfigs([typeof(BetaPluginConfig)]);
+            IConfigAccessor accessor = this.configService.CreateAccessor(typeof(BetaPluginConfig));
+            IConfigAccessorFor<BetaPluginConfig> typedAccessor = accessor.For<BetaPluginConfig>();
+
+            // Act
+            var config = typedAccessor.Get();
+
+            // Assert
+            Assert.IsNotNull(config);
+            Assert.AreEqual("base-value", config.FieldA);
+            Assert.AreEqual(500, config.FieldB);
+        }
+
+        [TestMethod]
+        public async Task ConfigAccessorSaveAsync_WithModifiedConfig_UpdatesFile()
+        {
+            if (this.testConfigPath == null || this.configService == null)
+                return;
+
+            // Arrange
+            Token token = this.tokenService!.CreateToken();
+            this.CreateConfigFile("BetaPluginConfig.BaseSettings.json",
+                "{\"FieldA\":\"initial\",\"FieldB\":100}");
+
+            this.configService.RegisterConfigs([typeof(BetaPluginConfig)]);
+            IConfigAccessor accessor = this.configService.CreateAccessor(typeof(BetaPluginConfig));
+            IConfigAccessorFor<BetaPluginConfig> typedAccessor = accessor.For<BetaPluginConfig>();
+
+            // Get and modify config
+            var config = typedAccessor.Get();
+            config.FieldA = "modified";
+            config.FieldB = 200;
+
+            // Act
+            await typedAccessor.SaveAsync(config);
+
+            // Assert
+            string filePath = Path.Combine(this.testConfigPath, "Config", "BetaPluginConfig.UserSettings.json");
+            string fileContent = File.ReadAllText(filePath);
+            Assert.IsTrue(fileContent.Contains("\"FieldA\":\"modified\""),
+                "User settings should contain modified FieldA");
+            Assert.IsTrue(fileContent.Contains("\"FieldB\":\"200\""),
+                "User settings should contain modified FieldB");
+        }
+
+        [TestMethod]
+        public async Task ConfigAccessorSaveAsync_RemovesRedundantUserSettings()
+        {
+            if (this.testConfigPath == null || this.configService == null)
+                return;
+
+            // Arrange
+            Token token = this.tokenService!.CreateToken();
+
+            // Create base config with value
+            this.CreateConfigFile("BetaPluginConfig.BaseSettings.json",
+                "{\"FieldA\":\"base-value\",\"FieldB\":100}");
+
+            // Create user config that overrides one value
+            this.CreateConfigFile("BetaPluginConfig.UserSettings.json",
+                "{\"FieldA\":\"user-override\"}");
+
+            this.configService.RegisterConfigs([typeof(BetaPluginConfig)]);
+            IConfigAccessor accessor = this.configService.CreateAccessor(typeof(BetaPluginConfig));
+            IConfigAccessorFor<BetaPluginConfig> typedAccessor = accessor.For<BetaPluginConfig>();
+
+            // Get config and set FieldA back to base value
+            var config = typedAccessor.Get();
+            config.FieldA = "base-value";  // Matches base value
+
+            // Act
+            await typedAccessor.SaveAsync(config);
+
+            // Assert
+            string userFilePath = Path.Combine(this.testConfigPath, "Config", "BetaPluginConfig.UserSettings.json");
+            string userContent = File.ReadAllText(userFilePath);
+
+            // Should remove FieldA from user settings since it matches base
+            Assert.IsFalse(userContent.Contains("FieldA"),
+                "User settings should not contain FieldA after resetting to base value");
+        }
+
+
+        private void CreateConfigFile(string fileName, string content)
+        {
+            if (this.testConfigPath == null)
+                return;
+
+            string dirPath = Path.Combine(this.testConfigPath, "Config");
+            Directory.CreateDirectory(dirPath);
+            File.WriteAllText(Path.Combine(dirPath, fileName), content);
+        }
+    }
+}

--- a/PlugHub.UnitTests/Services/ConfigServiceTests.cs
+++ b/PlugHub.UnitTests/Services/ConfigServiceTests.cs
@@ -1,0 +1,1079 @@
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Moq;
+using PlugHub.Services;
+using PlugHub.Shared.Extensions;
+using PlugHub.Shared.Interfaces.Services;
+using System.Text.Json.Serialization;
+using System.Text.Json;
+using PlugHub.Shared.Models;
+
+namespace PlugHub.UnitTests.Services
+{
+    [TestClass]
+    public class ConfigServiceTests
+    {
+        private Mock<ILogger<ConfigService>>? loggerMock;
+        private ITokenService? tokenService;
+        private string? testConfigPath;
+
+
+        // Dummy classes for testing
+        public class AlphaPluginConfig
+        {
+            public int FieldA { get; set; } = 50;
+            public bool FieldB { get; set; } = false;
+        }
+        public class BetaPluginConfig
+        {
+            public required string FieldA { get; set; } = "";
+            public int FieldB { get; set; } = 120;
+        }
+
+
+        [TestInitialize]
+        public void Setup()
+        {
+            Mock<ILogger<TokenService>> loggerToken = new Mock<ILogger<TokenService>>();
+
+            this.loggerMock = new Mock<ILogger<ConfigService>>();
+            this.tokenService = new TokenService(loggerToken.Object);
+            this.testConfigPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+
+            Directory.CreateDirectory(this.testConfigPath);
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            if (this.testConfigPath as string != null)
+                Directory.Delete(this.testConfigPath, true);
+        }
+
+
+        #region ConfigServiceTests: RegisterPluginConfiguration
+
+        [TestMethod]
+        public void RegisterPluginConfigurationsValidTypesRegistersSuccessfully()
+        {
+            if (this.loggerMock == null || this.loggerMock.Object == null || this.testConfigPath as string == null || this.tokenService == null)
+                return;
+
+            // Arrange
+            ConfigService configService = new(this.loggerMock.Object, this.tokenService, this.testConfigPath, this.testConfigPath);
+            List<Type> configTypes = [typeof(AlphaPluginConfig), typeof(BetaPluginConfig)];
+
+            string pluginAlphaConfigPath = Path.Combine(this.testConfigPath, "Config", "AlphaPluginConfig.BaseSettings.json");
+            string pluginBetaConfigPath = Path.Combine(this.testConfigPath, "Config", "BetaPluginConfig.UserSettings.json");
+
+            Directory.CreateDirectory(Path.Combine(this.testConfigPath, "Config"));
+
+            File.WriteAllText(pluginAlphaConfigPath, "{\r\n  \"FieldA\": 80,\r\n  \"FieldB\": true\r\n}");
+            File.WriteAllText(pluginBetaConfigPath, "{\r\n  \"FieldA\": \"1920x1080\",\r\n  \"FieldB\": 60\r\n}");
+
+            // Act
+            configService.RegisterConfigs(configTypes);
+
+            // Assert
+            // Verify settings retrieval
+            Assert.AreEqual(80, configService.GetSetting<int>(typeof(AlphaPluginConfig), "FieldA"));
+            Assert.AreEqual("1920x1080", configService.GetSetting<string>(typeof(BetaPluginConfig), "FieldA"));
+        }
+
+        [TestMethod]
+        public void RegisterPluginConfigurationsInvalidConfigThrowsException()
+        {
+            if (this.loggerMock == null || this.loggerMock.Object == null || this.testConfigPath as string == null || this.tokenService == null)
+                return;
+
+            // Arrange
+            ConfigService configService = new(this.loggerMock.Object, this.tokenService, this.testConfigPath, this.testConfigPath);
+            List<Type> configTypes = [typeof(AlphaPluginConfig)];
+
+            string pluginAlphaConfigPath = Path.Combine(this.testConfigPath, "Config", "AlphaPluginConfig.BaseSettings.json");
+
+            Directory.CreateDirectory(Path.Combine(this.testConfigPath, "Config"));
+
+            // Create invalid JSON file
+            File.WriteAllText(pluginAlphaConfigPath, "INVALID_JSON");
+
+            // Act & Assert
+            IOException ex = Assert.ThrowsException<IOException>(() =>
+                configService.RegisterConfigs(configTypes));
+
+            // Verify inner exception is JSON-related
+            Assert.IsInstanceOfType(ex, typeof(IOException));
+        }
+
+        #endregion
+
+        #region ConfigServiceTests: OnPluginConfigurationChanged
+
+        [TestMethod]
+        public async Task OnPluginConfigurationChangedValidTypeReloadsSettings()
+        {
+            if (this.loggerMock == null || this.loggerMock.Object == null || this.testConfigPath as string == null || this.tokenService == null)
+                return;
+
+            // Arrange
+            ConfigService configService = new(this.loggerMock.Object, this.tokenService, this.testConfigPath, this.testConfigPath);
+            List<Type> configTypes = [typeof(AlphaPluginConfig)];
+
+            // Create proper plugin directory
+            string pluginAlphaConfigPath = Path.Combine(this.testConfigPath, "Config", "AlphaPluginConfig.BaseSettings.json");
+
+            Directory.CreateDirectory(Path.Combine(this.testConfigPath, "Config"));
+
+            // Initial config
+            File.WriteAllText(pluginAlphaConfigPath, "{\"FieldA\": 80, \"FieldB\": true}");
+            configService.RegisterConfigs(configTypes);
+
+            // Set up event completion source
+            TaskCompletionSource<bool> reloadCompleted = new();
+            configService.ConfigReloaded += (sender, e) =>
+            {
+                if (e.ConfigType == typeof(AlphaPluginConfig))
+                    reloadCompleted.SetResult(true);
+            };
+
+            // Update config
+            File.WriteAllText(pluginAlphaConfigPath, "{\"FieldA\": 70, \"FieldB\": true}");
+
+            // Wait for reload event with timeout
+            Task completedTask = await Task.WhenAny(reloadCompleted.Task, Task.Delay(2000));
+            if (completedTask != reloadCompleted.Task)
+                Assert.Fail("PluginConfigurationReloaded event not raised within timeout");
+
+            // Assert
+            Assert.AreEqual(70, configService.GetSetting<int>(typeof(AlphaPluginConfig), "FieldA"));
+        }
+
+        [TestMethod]
+        public async Task MultipleReloadsProcessSequentially()
+        {
+            if (this.loggerMock == null || this.loggerMock.Object == null || this.testConfigPath as string == null || this.tokenService == null)
+                return;
+
+            // Arrange
+            ConfigService configService = new(this.loggerMock.Object, this.tokenService, this.testConfigPath, this.testConfigPath);
+            List<Type> configTypes = [typeof(AlphaPluginConfig)];
+
+            // This matches the path logic in ConfigService
+            string pluginAlphaConfigPath = Path.Combine(this.testConfigPath, "Config", "AlphaPluginConfig.BaseSettings.json");
+            Directory.CreateDirectory(Path.Combine(this.testConfigPath, "Config"));
+
+            // Initial config
+            File.WriteAllText(pluginAlphaConfigPath, "{\"FieldA\": 80}");
+            configService.RegisterConfigs(configTypes);
+
+            int reloadCount = 0;
+            Queue<TaskCompletionSource<bool>> reloadQueue = new();
+
+            configService.ConfigReloaded += (s, e) =>
+            {
+                if (e.ConfigType == typeof(AlphaPluginConfig))
+                {
+                    reloadCount++;
+                    if (reloadQueue.Count > 0)
+                        reloadQueue.Dequeue().SetResult(true);
+                }
+            };
+
+            for (int i = 0; i < 3; i++)
+            {
+                TaskCompletionSource<bool> reloadCompletion = new();
+                reloadQueue.Enqueue(reloadCompletion);
+
+                int newFieldA = 70 + i;
+                File.WriteAllText(pluginAlphaConfigPath, $"{{\"FieldA\": {newFieldA}}}");
+
+                await Task.WhenAny(reloadCompletion.Task);
+
+                Assert.AreEqual(
+                    newFieldA,
+                    configService.GetSetting<int>(typeof(AlphaPluginConfig), "FieldA"),
+                    $"FieldA mismatch after reload {i + 1}"
+                );
+            }
+
+            Assert.AreEqual(3, reloadCount, "Should have triggered 3 reload events");
+        }
+
+        #endregion
+
+        #region ConfigServiceTests: GetEnvironmentSettings
+
+        [TestMethod]
+        public void GetEnvironmentSettingsReturnsValidEnvironmentConfiguration()
+        {
+            if (this.loggerMock == null || this.loggerMock.Object == null || this.testConfigPath as string == null || this.tokenService == null)
+                return;
+
+            // Set test environment variables
+            string testKey = "TEST_ENV_VAR_" + Guid.NewGuid().ToString("N");
+            string expectedValue = "test_value_123";
+            Environment.SetEnvironmentVariable(testKey, expectedValue);
+
+            // Arrange
+            ConfigService configService = new(this.loggerMock.Object, this.tokenService, this.testConfigPath, this.testConfigPath);
+
+            // Act
+            IConfiguration envConfig = configService.GetEnvConfig();
+            string? actualValue = envConfig[testKey];
+
+            // Cleanup environment
+            Environment.SetEnvironmentVariable(testKey, null);
+
+            // Assert
+            Assert.AreEqual(expectedValue, actualValue);
+        }
+
+        [TestMethod]
+        public void GetEnvironmentSettingsReflectsEnvironmentVariableChangeAfterRebuild()
+        {
+            if (this.loggerMock == null || this.loggerMock.Object == null || this.testConfigPath as string == null || this.tokenService == null)
+                return;
+
+            // Set initial environment variable
+            string testKey = "TEST_ENV_VAR_" + Guid.NewGuid().ToString("N");
+            string initialValue = "initial_value";
+            string updatedValue = "updated_value";
+            Environment.SetEnvironmentVariable(testKey, initialValue);
+
+            // Arrange
+            ConfigService configService = new(this.loggerMock.Object, this.tokenService, this.testConfigPath, this.testConfigPath);
+
+            // Act 1: Read initial value
+            IConfiguration envConfig1 = configService.GetEnvConfig();
+            string? actualValue1 = envConfig1[testKey];
+            Assert.AreEqual(initialValue, actualValue1);
+
+            // Change the environment variable at runtime
+            Environment.SetEnvironmentVariable(testKey, updatedValue);
+
+            // Act 2: Rebuild the environment settings (simulate a refresh)
+            IConfiguration envConfig2 = configService.GetEnvConfig();
+            string? actualValue2 = envConfig2[testKey];
+
+            // Cleanup
+            Environment.SetEnvironmentVariable(testKey, null);
+
+            // Assert
+            Assert.AreEqual(updatedValue, actualValue2);
+        }
+
+
+        #endregion
+
+        #region ConfigServiceTests: GetAppSetting
+
+        [TestMethod]
+        public void GetAppSettingKeyExistsAndTypeMatchesReturnsValue()
+        {
+            if (this.loggerMock == null || this.loggerMock.Object == null || this.testConfigPath as string == null || this.tokenService == null)
+                return;
+
+            // Arrange
+            ConfigService configService = new(this.loggerMock.Object, this.tokenService, this.testConfigPath, this.testConfigPath);
+
+            // Set up appSettings dictionary via reflection
+            System.Reflection.FieldInfo? appSettingsField = typeof(ConfigService).GetField("appSettings",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+
+            if (appSettingsField == null)
+                return;
+
+            appSettingsField.SetValue(configService, new Dictionary<string, object?>
+            {
+                { "TestInt", 42 },
+                { "TestString", "hello" },
+                { "TestBool", true }
+            });
+
+            // Act & Assert
+            Assert.AreEqual(42, configService.GetAppSetting<int>("TestInt"));
+            Assert.AreEqual("hello", configService.GetAppSetting<string>("TestString"));
+            Assert.IsTrue(configService.GetAppSetting<bool>("TestBool"));
+        }
+
+        [TestMethod]
+        public void GetAppSettingKeyDoesNotExistThrowsKeyNotFoundException()
+        {
+            if (this.loggerMock == null || this.loggerMock.Object == null || this.testConfigPath as string == null || this.tokenService == null)
+                return;
+
+            // Arrange
+            ConfigService configService = new(this.loggerMock.Object, this.tokenService, this.testConfigPath, this.testConfigPath);
+
+            // Ensure appSettings is empty
+            System.Reflection.FieldInfo? appSettingsField = typeof(ConfigService).GetField("appSettings",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+
+            if (appSettingsField == null)
+                return;
+
+            appSettingsField.SetValue(configService, new Dictionary<string, object?>());
+
+            // Act & Assert
+            KeyNotFoundException ex = Assert.ThrowsException<KeyNotFoundException>(() =>
+                configService.GetAppSetting<int>("NonExistentKey"));
+            StringAssert.Contains(ex.Message, "Application setting with key 'NonExistentKey' not found");
+        }
+
+        [TestMethod]
+        public void GetAppSettingTypeMismatchThrowsInvalidCastException()
+        {
+            if (this.loggerMock == null || this.loggerMock.Object == null || this.testConfigPath as string == null || this.tokenService == null)
+                return;
+
+            // Arrange
+            ConfigService configService = new(this.loggerMock.Object, this.tokenService, this.testConfigPath, this.testConfigPath);
+
+            // Set up appSettings with type mismatch
+            System.Reflection.FieldInfo? appSettingsField = typeof(ConfigService).GetField("appSettings",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+
+            if (appSettingsField == null)
+                return;
+
+            appSettingsField.SetValue(configService, new Dictionary<string, object?>
+            {
+                { "TestKey", "string_value" }
+            });
+
+            // Act & Assert
+            InvalidCastException ex = Assert.ThrowsException<InvalidCastException>(() =>
+                configService.GetAppSetting<int>("TestKey"));
+            StringAssert.Contains(ex.Message, "cannot be cast to type 'System.Int32'");
+        }
+
+        #endregion
+
+        #region ConfigServiceTests: SetAppSetting
+
+        [TestMethod]
+        public void SetAppSettingNewKeyAddsKeyAndFiresEvent()
+        {
+            if (this.loggerMock == null || this.loggerMock.Object == null || this.testConfigPath as string == null || this.tokenService == null)
+                return;
+
+            // Arrange
+            ConfigService configService = new(this.loggerMock.Object, this.tokenService, this.testConfigPath, this.testConfigPath);
+
+            bool eventFired = false;
+            ConfigServiceAppSettingChangeEventArgs? eventArgs = null;
+            configService.AppSettingChanged += (s, e) =>
+            {
+                eventFired = true;
+                eventArgs = e;
+            };
+
+            // Act
+            configService.SetAppSetting("NewKey", 42);
+
+            // Assert
+            Assert.IsNotNull(eventArgs);
+            Assert.IsTrue(eventFired, "Event should be triggered for new key");
+            Assert.AreEqual("NewKey", eventArgs.Key);
+            Assert.IsNull(eventArgs.OldValue);
+            Assert.AreEqual(42, eventArgs.NewValue);
+            Assert.AreEqual(42, configService.GetAppSetting<int>("NewKey"));
+        }
+
+        [TestMethod]
+        public void SetAppSettingExistingKeySameValueNoChangeOrEvent()
+        {
+            if (this.loggerMock == null || this.loggerMock.Object == null || this.testConfigPath as string == null || this.tokenService == null)
+                return;
+
+            // Arrange
+            ConfigService configService = new(this.loggerMock.Object, this.tokenService, this.testConfigPath, this.testConfigPath);
+            configService.SetAppSetting("ExistingKey", 100); // Initial value
+
+            bool eventFired = false;
+            configService.AppSettingChanged += (s, e) => eventFired = true;
+
+            // Act
+            configService.SetAppSetting("ExistingKey", 100); // Same value
+
+            // Assert
+            Assert.IsFalse(eventFired, "Event should not fire for same value");
+            Assert.AreEqual(100, configService.GetAppSetting<int>("ExistingKey"));
+        }
+
+        [TestMethod]
+        public void SetAppSettingExistingKeyNewValueUpdatesAndFiresEvent()
+        {
+            if (this.loggerMock == null || this.loggerMock.Object == null || this.testConfigPath as string == null || this.tokenService == null)
+                return;
+
+            // Arrange
+            ConfigService configService = new(this.loggerMock.Object, this.tokenService, this.testConfigPath, this.testConfigPath);
+            configService.SetAppSetting("UpdateKey", "OldValue");
+
+            bool eventFired = false;
+            ConfigServiceAppSettingChangeEventArgs? eventArgs = null;
+            configService.AppSettingChanged += (s, e) =>
+            {
+                eventFired = true;
+                eventArgs = e;
+            };
+
+            // Act
+            configService.SetAppSetting("UpdateKey", "NewValue");
+
+            // Assert
+            Assert.IsNotNull(eventArgs);
+            Assert.IsTrue(eventFired, "Event should trigger for changed value");
+            Assert.AreEqual("UpdateKey", eventArgs.Key);
+            Assert.AreEqual("OldValue", eventArgs.OldValue);
+            Assert.AreEqual("NewValue", eventArgs.NewValue);
+            Assert.AreEqual("NewValue", configService.GetAppSetting<string>("UpdateKey"));
+        }
+
+        [TestMethod]
+        public void SetAppSettingTypeConversionFailureUpdatesAndFiresEvent()
+        {
+            if (this.loggerMock == null || this.loggerMock.Object == null || this.testConfigPath as string == null || this.tokenService == null)
+                return;
+
+            // Arrange
+            ConfigService configService = new(this.loggerMock.Object, this.tokenService, this.testConfigPath, this.testConfigPath);
+
+            // Set up appSettings with type mismatch via reflection
+            System.Reflection.FieldInfo? appSettingsField = typeof(ConfigService).GetField("appSettings",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+
+            if (appSettingsField == null)
+                return;
+
+            appSettingsField.SetValue(configService, new Dictionary<string, object?>
+            {
+                { "TestKey", "string_value" } // Will fail conversion to int
+            });
+
+            bool eventFired = false;
+            configService.AppSettingChanged += (s, e) => eventFired = true;
+
+            // Act
+            configService.SetAppSetting<int>("TestKey", 123);
+
+            // Assert
+            Assert.IsTrue(eventFired, "Event should fire despite conversion error");
+            Assert.AreEqual(123, configService.GetAppSetting<int>("TestKey"));
+        }
+
+        [TestMethod]
+        public void SetAppSettingNullValueHandlesCorrectly()
+        {
+            if (this.loggerMock == null || this.loggerMock.Object == null || this.testConfigPath as string == null || this.tokenService == null)
+                return;
+
+            // Arrange
+            ConfigService configService = new(this.loggerMock.Object, this.tokenService, this.testConfigPath, this.testConfigPath);
+            bool eventFired = false;
+            configService.AppSettingChanged += (s, e) => eventFired = true;
+
+            // Act
+            configService.SetAppSetting<string>("NullKey", null!);
+
+            // Assert
+            Assert.IsTrue(eventFired, "Event should fire for null value");
+            Assert.IsNull(configService.GetAppSetting<string>("NullKey"));
+        }
+
+        [TestMethod]
+        public void SetAppSettingMultipleThreadsThreadSafe()
+        {
+            if (this.loggerMock == null || this.loggerMock.Object == null || this.testConfigPath as string == null || this.tokenService == null)
+                return;
+
+            // Arrange
+            ConfigService configService = new(this.loggerMock.Object, this.tokenService, this.testConfigPath, this.testConfigPath);
+            int eventCount = 0;
+            configService.AppSettingChanged += (s, e) => Interlocked.Increment(ref eventCount);
+
+            // Act
+            Parallel.For(0, 100, i =>
+            {
+                configService.SetAppSetting($"Key_{i % 10}", i);
+            });
+
+            // Assert
+            Assert.AreEqual(100, eventCount, "All sets should trigger events");
+            for (int i = 0; i < 10; i++)
+            {
+                int finalValue = configService.GetAppSetting<int>($"Key_{i}");
+                Assert.IsTrue(finalValue >= 0 && finalValue < 100, "Value within expected range");
+            }
+        }
+
+        #endregion
+
+        #region ConfigServiceTests: SetSetting
+
+        [TestMethod]
+        public void SetSettingUpdatesValue()
+        {
+            if (this.loggerMock == null || this.loggerMock.Object == null || this.testConfigPath as string == null || this.tokenService == null)
+                return;
+
+            // Arrange
+            ConfigService configService = new(this.loggerMock.Object, this.tokenService, this.testConfigPath, this.testConfigPath);
+            configService.RegisterConfigs([typeof(AlphaPluginConfig)]);
+
+            bool eventFired = false;
+            configService.SettingChanged += (s, e) => eventFired = true;
+
+            // Act
+            configService.SetSetting(typeof(AlphaPluginConfig), "FieldA", 85);
+
+            // Assert
+            int value = configService.GetSetting<int>(typeof(AlphaPluginConfig), "FieldA");
+
+            Assert.AreEqual(85, value);
+            Assert.IsTrue(eventFired, "Setting changes should fire events");
+        }
+
+        [TestMethod]
+        public void SetSettingUserSettingNewValueUpdatesAndFiresEvent()
+        {
+            if (this.loggerMock == null || this.loggerMock.Object == null || this.testConfigPath as string == null || this.tokenService == null)
+                return;
+
+            // Create proper plugin directory
+            string pluginAlphaConfigPath = Path.Combine(this.testConfigPath, "Config", "AlphaPluginConfig.BaseSettings.json");
+
+            Directory.CreateDirectory(Path.Combine(this.testConfigPath, "Config"));
+
+            // Initial config
+            File.WriteAllText(pluginAlphaConfigPath, "{\"FieldA\": 80, \"FieldB\": true}");
+
+            // Arrange
+            ConfigService configService = new(this.loggerMock.Object, this.tokenService, this.testConfigPath, this.testConfigPath);
+            configService.RegisterConfigs([typeof(AlphaPluginConfig)]);
+
+            bool eventFired = false;
+            ConfigServiceSettingChangeEventArgs? eventArgs = null;
+            configService.SettingChanged += (s, e) =>
+            {
+                eventFired = true;
+                eventArgs = e;
+            };
+
+            // Act
+            configService.SetSetting(typeof(AlphaPluginConfig), "FieldA", 90);
+
+            // Assert
+            Assert.IsNotNull(eventArgs);
+            Assert.IsTrue(eventFired, "User setting changes should fire events");
+            Assert.AreEqual(typeof(AlphaPluginConfig), eventArgs.ConfigType);
+            Assert.AreEqual("FieldA", eventArgs.Key);
+            Assert.IsNotNull(eventArgs.OldValue);
+            Assert.AreEqual(90, eventArgs.NewValue);
+            Assert.AreEqual(90, configService.GetSetting<int>(typeof(AlphaPluginConfig), "FieldA"));
+        }
+
+        [TestMethod]
+        public void SetSettingUserSettingEqualsBaseValueRemovesOverrideAndFiresEvent()
+        {
+            if (this.loggerMock == null || this.loggerMock.Object == null || this.testConfigPath as string == null || this.tokenService == null)
+                return;
+
+            // Arrange
+            ConfigService configService = new(this.loggerMock.Object, this.tokenService, this.testConfigPath, this.testConfigPath);
+            configService.RegisterConfigs([typeof(AlphaPluginConfig)]);
+
+            // Set base value
+            configService.SetSetting(typeof(AlphaPluginConfig), "FieldA", 80);
+
+            // Set user override
+            configService.SetSetting(typeof(AlphaPluginConfig), "FieldA", 85);
+
+            bool eventFired = false;
+            configService.SettingChanged += (s, e) => eventFired = true;
+
+            // Act
+            configService.SetSetting(typeof(AlphaPluginConfig), "FieldA", 80); // Revert to base value
+
+            // Assert
+            Assert.IsTrue(eventFired, "Reverting to base value should fire event");
+            Assert.AreEqual(80, configService.GetSetting<int>(typeof(AlphaPluginConfig), "FieldA"));
+        }
+
+        [TestMethod]
+        public void SetSettingUserSettingDifferentValueUpdatesAndFiresEvent()
+        {
+            if (this.loggerMock == null || this.loggerMock.Object == null || this.testConfigPath as string == null || this.tokenService == null)
+                return;
+
+            // Arrange
+            ConfigService configService = new(this.loggerMock.Object, this.tokenService, this.testConfigPath, this.testConfigPath);
+            configService.RegisterConfigs([typeof(AlphaPluginConfig)]);
+
+            // Set initial user value
+            configService.SetSetting(typeof(AlphaPluginConfig), "FieldA", 75);
+
+            bool eventFired = false;
+            ConfigServiceSettingChangeEventArgs? eventArgs = null;
+            configService.SettingChanged += (s, e) =>
+            {
+                eventFired = true;
+                eventArgs = e;
+            };
+
+            // Act
+            configService.SetSetting(typeof(AlphaPluginConfig), "FieldA", 85);
+
+            // Assert
+            Assert.IsNotNull(eventArgs);
+            Assert.IsTrue(eventFired, "Value change should fire event");
+            Assert.AreEqual(75, eventArgs.OldValue);
+            Assert.AreEqual(85, eventArgs.NewValue);
+            Assert.AreEqual(85, configService.GetSetting<int>(typeof(AlphaPluginConfig), "FieldA"));
+        }
+
+        [TestMethod]
+        public void SetSettingUnregisteredPluginTypeThrowsException()
+        {
+            if (this.loggerMock == null || this.loggerMock.Object == null || this.testConfigPath as string == null || this.tokenService == null)
+                return;
+
+            // Arrange
+            ConfigService configService = new(this.loggerMock.Object, this.tokenService, this.testConfigPath, this.testConfigPath);
+
+            // Act & Assert
+            InvalidOperationException ex = Assert.ThrowsException<InvalidOperationException>(() =>
+                configService.SetSetting(typeof(AlphaPluginConfig), "FieldA", 80));
+            StringAssert.Contains(ex.Message, "Plugin configuration not registered");
+        }
+
+        [TestMethod]
+        public void SetSettingNullValueHandlesCorrectly()
+        {
+            if (this.loggerMock == null || this.loggerMock.Object == null || this.testConfigPath as string == null || this.tokenService == null)
+                return;
+
+            // Arrange
+            ConfigService configService = new(this.loggerMock.Object, this.tokenService, this.testConfigPath, this.testConfigPath);
+            configService.RegisterConfigs([typeof(BetaPluginConfig)]);
+
+            bool eventFired = false;
+            configService.SettingChanged += (s, e) => eventFired = true;
+
+            // Act
+            configService.SetSetting<string>(typeof(BetaPluginConfig), "FieldA", null!);
+
+            // Assert
+            Assert.IsTrue(eventFired, "Null value should fire event");
+            Assert.IsNull(configService.GetSetting<string>(typeof(BetaPluginConfig), "FieldA"));
+        }
+
+        [TestMethod]
+        public void SetSettingTypeConversionHandlesCorrectly()
+        {
+            if (this.loggerMock == null || this.loggerMock.Object == null || this.testConfigPath as string == null || this.tokenService == null)
+                return;
+
+            // Arrange
+            ConfigService configService = new(this.loggerMock.Object, this.tokenService, this.testConfigPath, this.testConfigPath);
+            configService.RegisterConfigs([typeof(AlphaPluginConfig)]);
+
+            // Set initial value as int
+            configService.SetSetting(typeof(AlphaPluginConfig), "FieldA", 80);
+
+            bool eventFired = false;
+            configService.SettingChanged += (s, e) => eventFired = true;
+
+            // Act & Assert
+            // Change to string - should work despite type difference
+            configService.SetSetting(typeof(AlphaPluginConfig), "FieldA", "90");
+
+            Assert.IsTrue(eventFired, "Type change should fire event");
+            Assert.AreEqual("90", configService.GetSetting<string>(typeof(AlphaPluginConfig), "FieldA"));
+        }
+
+        #endregion
+
+        #region ConfigServiceTests: SaveAppSettings
+
+        [TestMethod]
+        public async Task SaveAppSettingsWritesAppSettingsToFileAsync()
+        {
+            if (this.loggerMock == null || this.loggerMock.Object == null ||
+                this.testConfigPath as string == null || this.tokenService == null)
+                return;
+
+            // Arrange
+            ConfigService configService = new(this.loggerMock.Object, this.tokenService,
+                                              this.testConfigPath, this.testConfigPath);
+            configService.SetAppSetting("TestKey", 123);
+            string appSettingsPath = Path.Combine(this.testConfigPath, "appsettings.json");
+
+            // Act
+            await configService.SaveAppSettingsAsync();
+
+            // Assert
+            Assert.IsTrue(File.Exists(appSettingsPath), "appsettings.json file should be created");
+            string json = File.ReadAllText(appSettingsPath);
+            Assert.IsTrue(json.Contains("TestKey") && json.Contains("123"),
+                         "File should contain saved key and value");
+        }
+
+        [TestMethod]
+        public async Task SaveAppSettingsWhenSaveFailsThrowsIOException()
+        {
+            if (this.loggerMock == null || this.loggerMock.Object == null ||
+                this.testConfigPath as string == null || this.tokenService == null)
+                return;
+
+            // Arrange
+            ConfigService configService = new(this.loggerMock.Object, this.tokenService,
+                                              this.testConfigPath, this.testConfigPath);
+            configService.SetAppSetting("TestKey", 123);
+
+            // Create a read-only file to force IOException
+            string appSettingsPath = Path.Combine(this.testConfigPath, "appsettings.json");
+            File.WriteAllText(appSettingsPath, "{}");
+            File.SetAttributes(appSettingsPath, FileAttributes.ReadOnly);
+
+            try
+            {
+                // Act & Assert
+                IOException ex = await Assert.ThrowsExceptionAsync<IOException>(
+                    () => configService.SaveAppSettingsAsync()
+                );
+                StringAssert.Contains(ex.Message, "Failed to save application settings.");
+            }
+            finally
+            {
+                // Cleanup
+                File.SetAttributes(appSettingsPath, FileAttributes.Normal);
+                File.Delete(appSettingsPath);
+            }
+        }
+
+        [TestMethod]
+        public void SaveAppSettingsSerializesEmptyDictionary()
+        {
+            if (this.loggerMock == null || this.loggerMock.Object == null || this.testConfigPath as string == null || this.tokenService == null)
+                return;
+
+            // Arrange
+            ConfigService configService = new(this.loggerMock.Object, this.tokenService, this.testConfigPath, this.testConfigPath);
+            string appSettingsPath = Path.Combine(this.testConfigPath, "appsettings.json");
+
+            // Act
+            configService.SaveAppSettingsAsync();
+
+            // Assert
+            Assert.IsTrue(File.Exists(appSettingsPath), "appsettings.json file should be created");
+            string json = File.ReadAllText(appSettingsPath);
+            Assert.IsTrue(json.Trim() == "{}" || json.Trim() == "{\r\n}", "File should contain an empty JSON object");
+        }
+
+        #endregion
+
+        #region ConfigServiceTests: SaveSettings
+
+        [TestMethod]
+        public async Task SaveSettingsValidConfigTypeSavesFilesAsync()
+        {
+            if (this.loggerMock == null || this.loggerMock.Object == null ||
+                this.testConfigPath as string == null || this.tokenService == null)
+                return;
+
+            // Arrange
+            ConfigService configService = new(this.loggerMock.Object, this.tokenService,
+                                              this.testConfigPath, this.testConfigPath);
+            configService.RegisterConfig(typeof(AlphaPluginConfig));
+
+            // Set sample settings
+            configService.SetSetting(typeof(AlphaPluginConfig), "FieldB", true);
+
+            string userSettingsPath = Path.Combine(this.testConfigPath, "Config", "AlphaPluginConfig.UserSettings.json");
+
+            // Act
+            await configService.SaveSettingsAsync(typeof(AlphaPluginConfig));
+
+            // Assert
+            Assert.IsTrue(File.Exists(userSettingsPath), "User settings file should be created");
+            string userJson = File.ReadAllText(userSettingsPath);
+            Assert.IsTrue(userJson.Contains("\"FieldB\": true") || userJson.Contains("\"FieldB\":true"),
+                "User settings should contain test value");
+        }
+
+        [TestMethod]
+        public async Task SaveSettingsUnregisteredConfigTypeThrowsExceptionAsync()
+        {
+            if (this.loggerMock == null || this.loggerMock.Object == null ||
+                this.testConfigPath as string == null || this.tokenService == null)
+                return;
+
+            // Arrange
+            ConfigService configService = new(this.loggerMock.Object, this.tokenService, this.testConfigPath, this.testConfigPath);
+
+            // Act & Assert
+            IOException ex = await Assert.ThrowsExceptionAsync<IOException>(() =>
+                configService.SaveSettingsAsync(typeof(AlphaPluginConfig)));
+            StringAssert.Contains(ex.Message, "Failed to save settings for 'AlphaPluginConfig'");
+        }
+
+        [TestMethod]
+        public async Task SaveSettingsWhenFileWriteFailsThrowsIOExceptionAsync()
+        {
+            if (this.loggerMock == null || this.loggerMock.Object == null ||
+                this.testConfigPath as string == null || this.tokenService == null)
+                return;
+
+            // Arrange
+            ConfigService configService = new(this.loggerMock.Object, this.tokenService,
+                                              this.testConfigPath, this.testConfigPath);
+            configService.RegisterConfig(typeof(AlphaPluginConfig));
+
+            // Create and set files as read-only
+            string userSettingsPath = Path.Combine(this.testConfigPath, "Config", "AlphaPluginConfig.UserSettings.json");
+            string baseSettingsPath = Path.Combine(this.testConfigPath, "Config", "AlphaPluginConfig.BaseSettings.json");
+
+            Directory.CreateDirectory(Path.GetDirectoryName(userSettingsPath) ?? "");
+            File.WriteAllText(userSettingsPath, "{}");
+            File.WriteAllText(baseSettingsPath, "{}");
+
+            // Set files (not directory) as read-only
+            new FileInfo(userSettingsPath).IsReadOnly = true;
+            new FileInfo(baseSettingsPath).IsReadOnly = true;
+
+            try
+            {
+                // Act & Assert
+                IOException ex = await Assert.ThrowsExceptionAsync<IOException>(() =>
+                    configService.SaveSettingsAsync(typeof(AlphaPluginConfig)));
+                StringAssert.Contains(ex.Message, "Failed to save settings for 'AlphaPluginConfig'");
+            }
+            finally
+            {
+                // Cleanup
+                new FileInfo(userSettingsPath).IsReadOnly = false;
+                new FileInfo(baseSettingsPath).IsReadOnly = false;
+                File.Delete(userSettingsPath);
+                File.Delete(baseSettingsPath);
+            }
+        }
+
+
+        [TestMethod]
+        public void SaveSettingsEmptySettingsSavesValidJson()
+        {
+            if (this.loggerMock == null || this.loggerMock.Object == null || this.testConfigPath as string == null || this.tokenService == null)
+                return;
+
+            // Arrange
+            ConfigService configService = new(this.loggerMock.Object, this.tokenService, this.testConfigPath, this.testConfigPath);
+            configService.RegisterConfig(typeof(BetaPluginConfig));
+
+            string baseSettingsPath = Path.Combine(this.testConfigPath, "Config", "BetaPluginConfig.BaseSettings.json");
+            string userSettingsPath = Path.Combine(this.testConfigPath, "Config", "BetaPluginConfig.UserSettings.json");
+
+            // Act
+            configService.SaveSettingsAsync(typeof(BetaPluginConfig));
+
+            // Assert
+            string baseJson = File.ReadAllText(baseSettingsPath);
+            string userJson = File.ReadAllText(userSettingsPath);
+
+
+            Assert.AreEqual(typeof(BetaPluginConfig).SerializeToJson(new JsonSerializerOptions
+            {
+                NumberHandling = JsonNumberHandling.WriteAsString,
+            }), baseJson.Trim(), "Empty user settings should save the default");
+
+            Assert.AreEqual("{}", userJson.Trim(), "Empty base settings should save as {}");
+        }
+
+        #endregion
+
+        #region ConfigServiceTests: ITokenService
+
+        [TestMethod]
+        public void GetSettingWithValidTokenReturnsValue()
+        {
+            if (this.loggerMock == null || this.loggerMock.Object == null || this.testConfigPath as string == null || this.tokenService == null)
+                return;
+
+            // Arrange
+            Token token = this.tokenService.CreateToken();
+            ConfigService configService = new(this.loggerMock.Object, this.tokenService, this.testConfigPath, this.testConfigPath);
+            configService.RegisterConfig(typeof(AlphaPluginConfig), readToken: token);
+            configService.SetSetting(typeof(AlphaPluginConfig), "ApiKey", "test-value", token: token);
+
+            // Act
+            string result = configService.GetSetting<string>(typeof(AlphaPluginConfig), "ApiKey", token);
+
+            // Assert
+            Assert.AreEqual("test-value", result);
+        }
+
+        [TestMethod]
+        public void GetSettingWithoutTokenThrowsWhenTokenRequired()
+        {
+            if (this.loggerMock == null || this.loggerMock.Object == null || this.testConfigPath as string == null || this.tokenService == null)
+                return;
+
+            // Arrange
+            Token token = this.tokenService.CreateToken();
+            ConfigService configService = new(this.loggerMock.Object, this.tokenService, this.testConfigPath, this.testConfigPath);
+            configService.RegisterConfig(typeof(AlphaPluginConfig), readToken: token);
+
+            // Act & Assert
+            Assert.ThrowsException<UnauthorizedAccessException>(() =>
+                configService.GetSetting<string>(typeof(AlphaPluginConfig), "FieldA"));
+        }
+
+        [TestMethod]
+        public void SetSettingWithInvalidTokenThrowsUnauthorized()
+        {
+            if (this.loggerMock == null || this.loggerMock.Object == null || this.testConfigPath as string == null || this.tokenService == null)
+                return;
+
+            // Arrange
+            Token validToken = this.tokenService.CreateToken();
+            Token invalidToken = this.tokenService.CreateToken();
+
+            ConfigService configService = new(this.loggerMock.Object, this.tokenService, this.testConfigPath, this.testConfigPath);
+
+            configService.RegisterConfig(typeof(AlphaPluginConfig), writeToken: validToken);
+
+            // Act & Assert
+            Assert.ThrowsException<UnauthorizedAccessException>(() =>
+                configService.SetSetting(typeof(AlphaPluginConfig), "ApiKey", "new-value", token: invalidToken));
+        }
+
+        #endregion
+
+        #region ConfigServiceTests: BaseConfig
+
+        [TestMethod]
+        public async Task SaveAndGetBaseConfigFileContentsSucceeds()
+        {
+            if (this.loggerMock == null || this.loggerMock.Object == null || this.testConfigPath as string == null || this.tokenService == null)
+                return;
+
+            // Arrange
+            ConfigService configService = new ConfigService(this.loggerMock.Object, this.tokenService, this.testConfigPath, this.testConfigPath);
+            Token writeToken = this.tokenService.CreateToken();
+            Token readToken = this.tokenService.CreateToken();
+            configService.RegisterConfig(typeof(AlphaPluginConfig), readToken: readToken, writeToken: writeToken);
+
+            string expectedContents = "{ \"FieldA\": 123, \"FieldB\": true }";
+
+            // Act
+            await configService.SaveBaseConfigFileContentsAsync(typeof(AlphaPluginConfig), expectedContents, writeToken);
+            string actualContents = configService.GetBaseConfigFileContents(typeof(AlphaPluginConfig), readToken);
+
+            // Assert
+            Assert.AreEqual(expectedContents, actualContents);
+        }
+
+        [TestMethod]
+        public async Task SaveBaseConfigFileContents_InvalidToken_ThrowsUnauthorizedAsync()
+        {
+            // Arrange
+            if (this.loggerMock?.Object == null || this.testConfigPath == null || this.tokenService == null)
+                return;
+
+            var configService = new ConfigService(this.loggerMock.Object, this.tokenService, this.testConfigPath, this.testConfigPath);
+            var validToken = this.tokenService.CreateToken();
+            var invalidToken = this.tokenService.CreateToken();
+
+            configService.RegisterConfig(typeof(BetaPluginConfig), writeToken: validToken);
+
+            // Act & Assert
+            await Assert.ThrowsExceptionAsync<UnauthorizedAccessException>(async () =>
+                await configService.SaveBaseConfigFileContentsAsync(typeof(BetaPluginConfig), "{}", invalidToken));
+        }
+
+        [TestMethod]
+        public void GetBaseConfigFileContentsInvalidTokenThrowsUnauthorized()
+        {
+            if (this.loggerMock == null || this.loggerMock.Object == null || this.testConfigPath as string == null || this.tokenService == null)
+                return;
+
+            // Arrange
+            ConfigService configService = new ConfigService(this.loggerMock.Object, this.tokenService, this.testConfigPath, this.testConfigPath);
+            Token validToken = this.tokenService.CreateToken();
+            Token invalidToken = this.tokenService.CreateToken();
+            configService.RegisterConfig(typeof(AlphaPluginConfig), readToken: validToken, writeToken: validToken);
+
+            // Write a config file first
+            configService.SaveBaseConfigFileContentsAsync(typeof(AlphaPluginConfig), "{}", validToken);
+
+            // Act & Assert
+            Assert.ThrowsException<UnauthorizedAccessException>(() =>
+                configService.GetBaseConfigFileContents(typeof(AlphaPluginConfig), invalidToken));
+        }
+
+        [TestMethod]
+        public void GetBaseConfigFileContentsFileNotFoundThrows()
+        {
+            if (this.loggerMock == null || this.loggerMock.Object == null || this.testConfigPath as string == null || this.tokenService == null)
+                return;
+
+            // Arrange
+            ConfigService configService = new ConfigService(this.loggerMock.Object, this.tokenService, this.testConfigPath, this.testConfigPath);
+            Token token = this.tokenService.CreateToken();
+            configService.RegisterConfig(typeof(BetaPluginConfig), readToken: token);
+
+            // Act & Assert
+            Assert.ThrowsException<FileNotFoundException>(() =>
+                configService.GetBaseConfigFileContents(typeof(AlphaPluginConfig), token));
+        }
+
+        [TestMethod]
+        public async Task SaveBaseConfigFileContentsCreatesDirectoryIfNotExists()
+        {
+            if (this.loggerMock == null || this.loggerMock.Object == null || this.testConfigPath as string == null || this.tokenService == null)
+                return;
+
+            // Arrange
+            ConfigService configService = new ConfigService(this.loggerMock.Object, this.tokenService, this.testConfigPath, this.testConfigPath);
+            Token token = this.tokenService.CreateToken();
+            configService.RegisterConfig(typeof(AlphaPluginConfig), writeToken: token);
+
+            // Simulate non-existent directory by deleting it
+            Directory.Delete(this.testConfigPath, recursive: true);
+
+            // Act
+            string contents = "{ \"FieldA\": 1, \"FieldB\": false }";
+            await configService.SaveBaseConfigFileContentsAsync(typeof(AlphaPluginConfig), contents, token);
+
+            // Assert
+            // Directory and file should exist now
+            string settingPath = Path.Combine(this.testConfigPath, "Config", "AlphaPluginConfig.BaseSettings.json"); ;
+
+            Assert.IsTrue(File.Exists(settingPath));
+            Assert.AreEqual(contents, File.ReadAllText(settingPath));
+        }
+
+        [TestMethod]
+        public async Task GenericOverloadsWorkAsExpected()
+        {
+            if (this.loggerMock == null || this.loggerMock.Object == null || this.testConfigPath as string == null || this.tokenService == null)
+                return;
+            // Arrange
+            ConfigService configService = new ConfigService(this.loggerMock.Object, this.tokenService, this.testConfigPath, this.testConfigPath);
+            Token token = this.tokenService.CreateToken();
+            configService.RegisterConfig(typeof(AlphaPluginConfig), readToken: token, writeToken: token);
+
+            string contents = "{ \"FieldA\": 99, \"FieldB\": true }";
+
+            // Act
+            await configService.SaveBaseConfigFileContentsAsync<AlphaPluginConfig>(contents, token);
+            string actual = configService.GetBaseConfigFileContents<AlphaPluginConfig>(token);
+
+            // Assert
+            Assert.AreEqual(contents, actual);
+        }
+
+        #endregion
+    }
+}

--- a/PlugHub/App.axaml.cs
+++ b/PlugHub/App.axaml.cs
@@ -71,6 +71,15 @@ public partial class App : Application
 
             return new TokenService(logger);
         });
+
+        services.AddSingleton<IConfigService>(provider =>
+        {
+            ILogger<ConfigService> logger = logger = new NullLogger<ConfigService>();
+            ITokenService tokenService = provider.GetRequiredService<ITokenService>();
+            string userRoot = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "PlugHub");
+
+            return new ConfigService(logger, tokenService, AppDomain.CurrentDomain.BaseDirectory, userRoot);
+        });
     }
 
     private static void DisableAvaloniaDataAnnotationValidation()

--- a/PlugHub/Services/ConfigAccessor.cs
+++ b/PlugHub/Services/ConfigAccessor.cs
@@ -1,0 +1,69 @@
+﻿using PlugHub.Shared.Interfaces.Services;
+using PlugHub.Shared.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace PlugHub.Services
+{
+    public class ConfigAccessor(IConfigService service, IEnumerable<Type> configTypes, Token readToken, Token writeToken) : IConfigAccessor, IDisposable
+    {
+        private readonly IConfigService service = service;
+        private readonly IEnumerable<Type> configTypes = configTypes;
+        private readonly Token readToken = readToken;
+        private readonly Token writeToken = writeToken;
+
+        public IConfigAccessorFor<TConfig> For<TConfig>() where TConfig : class
+        {
+            if (!this.configTypes.Contains(typeof(TConfig)))
+            {
+                throw new TypeAccessException(
+                    $"Configuration type {typeof(TConfig).Name} is not accessible through this accessor. " +
+                    $"Registered types: {string.Join(", ", this.configTypes.Select(t => t.Name))}"
+                );
+            }
+
+            return new ConfigAccessorFor<TConfig>(this.service, this.readToken, this.writeToken);
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+
+    public class ConfigAccessorFor<TConfig>(IConfigService service, Token readToken, Token writeToken) : IDisposable, IConfigAccessorFor<TConfig> where TConfig : class
+    {
+        private readonly IConfigService service = service;
+        private readonly Token readToken = readToken;
+        private readonly Token writeToken = writeToken;
+
+
+        TConfig IConfigAccessorFor<TConfig>.Get()
+        {
+            var instance = this.service.GetConfigInstance(typeof(TConfig), this.readToken);
+            return instance as TConfig
+                ?? throw new InvalidCastException($"Invalid config type for {typeof(TConfig)}");
+        }
+
+        async Task IConfigAccessorFor<TConfig>.SaveAsync(TConfig config)
+        {
+            this.service.SaveConfigInstance(typeof(TConfig), config, this.writeToken);
+
+            await this.service.SaveSettingsAsync(typeof(TConfig), this.writeToken);
+        }
+
+        T IConfigAccessorFor<TConfig>.Get<T>(string key)
+            => this.service.GetSetting<T>(typeof(TConfig), key, this.readToken);
+
+        void IConfigAccessorFor<TConfig>.Set<T>(string key, T value)
+            => this.service.SetSetting(typeof(TConfig), key, value, this.writeToken);
+
+        async Task IConfigAccessorFor<TConfig>.SaveAsync()
+            => await this.service.SaveSettingsAsync(typeof(TConfig), this.writeToken);
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/PlugHub/Services/ConfigService.cs
+++ b/PlugHub/Services/ConfigService.cs
@@ -1,0 +1,641 @@
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using PlugHub.Shared.Extensions;
+using PlugHub.Shared.Interfaces.Services;
+using PlugHub.Shared.Models;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PlugHub.Services
+{
+    public class ConfigServiceConfig(IConfiguration baseConfig, IConfiguration userConfig, Token? read = null, Token? write = null)
+    {
+        public IConfiguration BaseConfig = baseConfig;
+        public IConfiguration UserConfig = userConfig;
+        public Token Read = read ?? Token.Public;
+        public Token Write = write ?? read ?? Token.Public;
+    }
+    public class ConfigServiceSettings(Dictionary<string, object> baseSettings, Dictionary<string, object> userSettings, Token? read = null, Token? write = null)
+    {
+        public Dictionary<string, object> BaseSettings = baseSettings;
+        public Dictionary<string, object> UserSettings = userSettings;
+        public Token Read = read ?? Token.Public;
+        public Token Write = write ?? read ?? Token.Public;
+    }
+
+
+    public class ConfigService : IConfigService
+    {
+        public event EventHandler<EventArgs>? AppConfigReloaded;
+        public event EventHandler<ConfigServiceConfigReloadedEventArgs>? ConfigReloaded;
+        public event EventHandler<ConfigServiceAppSettingChangeEventArgs>? AppSettingChanged;
+        public event EventHandler<ConfigServiceSettingChangeEventArgs>? SettingChanged;
+
+        private readonly ILogger<ConfigService> logger;
+        private readonly ITokenService tokenService;
+
+        private readonly IConfiguration appConfig;
+        private readonly Dictionary<Type, ConfigServiceConfig> configs = [];
+        private readonly Dictionary<string, object> appSettings = [];
+        private readonly Dictionary<Type, ConfigServiceSettings> settings = [];
+
+        private readonly JsonSerializerOptions jsonOptions;
+        private const string configFolderPath = "Config";
+        private readonly string configRootDirectory;
+        private readonly string configUserDirectory;
+
+        private static readonly object iolock = new();
+        private readonly SemaphoreSlim aiolock = new SemaphoreSlim(1, 1);
+
+        public ConfigService(ILogger<ConfigService> logger, ITokenService tokenService, string configRootDirectory, string configUserDirectory)
+        {
+            this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            this.tokenService = tokenService;
+
+            string appSettingsFilePath = Path.Combine(configRootDirectory, "appsettings.json");
+            string appSettingsDevelopmentFilePath = Path.Combine(configRootDirectory, "appsettings.Development.json");
+
+            this.EnsureFileExists(appSettingsFilePath, optional: false);
+            this.EnsureFileExists(appSettingsDevelopmentFilePath, optional: true);
+
+            IConfigurationBuilder confBuilder = new ConfigurationBuilder()
+                .SetBasePath(Directory.GetCurrentDirectory())
+                .AddJsonFile(appSettingsFilePath, optional: false, reloadOnChange: true)
+                .AddJsonFile(appSettingsDevelopmentFilePath, optional: true, reloadOnChange: true);
+
+            this.appConfig = confBuilder.Build();
+            this.appConfig.GetReloadToken().RegisterChangeCallback(this.OnAppConfigChanged, null);
+
+            this.configRootDirectory = configRootDirectory;
+            this.configUserDirectory = configUserDirectory;
+
+            this.jsonOptions = new JsonSerializerOptions
+            {
+                NumberHandling = JsonNumberHandling.WriteAsString,
+            };
+
+            this.LoadAppSettings();
+        }
+
+
+        public IConfigAccessor CreateAccessor(Type configTypes, Token? readToken = null, Token? writeToken = null)
+        {
+            Token secRead = readToken ?? Token.Public;
+            Token secWrite = writeToken ?? secRead;
+
+            this.RegisterConfig(configTypes, secRead, secWrite);
+
+            return new ConfigAccessor(this, [configTypes], secRead, secWrite);
+        }
+        public IConfigAccessor CreateAccessor(IEnumerable<Type> configTypes, Token? readToken = null, Token? writeToken = null)
+        {
+            Token secRead = readToken ?? Token.Public;
+            Token secWrite = writeToken ?? secRead;
+
+            this.RegisterConfigs(configTypes, secRead, secWrite);
+
+            return new ConfigAccessor(this, configTypes, secRead, secWrite);
+        }
+
+
+        public void RegisterConfig(Type configType, Token? readToken = null, Token? writeToken = null)
+        {
+            Token secRead = readToken ?? Token.Public;
+            Token secWrite = writeToken ?? secRead;
+
+            bool configExists = this.settings.TryGetValue(configType, out ConfigServiceSettings? existingSettings);
+
+            if (configExists)
+            {
+                if (existingSettings != null)
+                    if (!this.tokenService.ValidateAccessor(existingSettings.Write, secWrite, false))
+                        throw new UnauthorizedAccessException(
+                            $"Write token invalid for existing config: {configType.Name}");
+            }
+            else
+            {
+                // No existing config - only validate if token isn't blocked
+                if (secWrite == Token.Blocked)
+                    throw new UnauthorizedAccessException(
+                        $"Blocked token cannot register new config: {configType.Name}");
+            }
+
+            string pluginName = configType.Name;
+            string baseConfigFilePath = this.GetSettingsPath(configType, true);
+            string userConfigFilePath = this.GetSettingsPath(configType, false);
+
+            this.EnsureFileExists(baseConfigFilePath, false, configType);
+            this.EnsureFileExists(userConfigFilePath, false);
+
+            IConfiguration baseConfig = BuildConfig(baseConfigFilePath);
+            IConfiguration userConfig = BuildConfig(userConfigFilePath);
+
+            this.configs[configType] = new(baseConfig, userConfig, secRead, secWrite);
+
+            Dictionary<string, object> baseSettings = [];
+            Dictionary<string, object> userSettings = [];
+
+            try
+            {
+                LoadSettings(baseConfig, baseSettings);
+                LoadSettings(userConfig, userSettings);
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidOperationException($"Error loading settings for plugin '{pluginName}'", ex);
+            }
+
+            this.settings[configType] = new(baseSettings, userSettings, secRead, secWrite);
+
+            baseConfig.GetReloadToken().RegisterChangeCallback(this.OnConfigChanged, configType);
+            userConfig.GetReloadToken().RegisterChangeCallback(this.OnConfigChanged, configType);
+        }
+        public void RegisterConfigs(IEnumerable<Type> configTypes, Token? readToken = null, Token? writeToken = null)
+        {
+            if (configTypes == null)
+                throw new ArgumentNullException(nameof(configTypes), "Configuration types collection cannot be null.");
+
+            lock (iolock)
+            {
+                foreach (Type configType in configTypes)
+                    this.RegisterConfig(configType, readToken, writeToken);
+            }
+        }
+
+        public IConfiguration GetEnvConfig()
+        {
+            return new ConfigurationBuilder()
+                .SetBasePath(Directory.GetCurrentDirectory())
+                .AddEnvironmentVariables()
+                .AddCommandLine(Environment.GetCommandLineArgs())
+                .Build();
+        }
+
+        public T GetAppSetting<T>(string key)
+        {
+            if (this.appSettings.TryGetValue(key, out object? value))
+            {
+                // Handle null for reference types
+                if (value == null && default(T) == null)
+                {
+                    return (T)value!;
+                }
+
+                if (value is T typedValue)
+                {
+                    return typedValue;
+                }
+                else
+                {
+                    throw new InvalidCastException($"The value for key '{key}' cannot be cast to type '{typeof(T).FullName}'.");
+                }
+            }
+            else
+            {
+                throw new KeyNotFoundException($"Application setting with key '{key}' not found.");
+            }
+        }
+        public T GetSetting<T>(Type configType, string key, Token? token = null)
+        {
+            Token secToken = token ?? Token.Public;
+
+            if (this.settings.TryGetValue(configType, out ConfigServiceSettings? settings))
+            {
+                this.tokenService.ValidateAccessor(settings.Read, secToken);
+
+                if (settings.UserSettings.TryGetValue(key, out object? userValue))
+                {
+                    return (T)Convert.ChangeType(userValue, typeof(T));
+                }
+
+                if (settings.BaseSettings.TryGetValue(key, out object? baseValue))
+                {
+                    return (T)Convert.ChangeType(baseValue, typeof(T));
+                }
+
+                throw new KeyNotFoundException($"Setting '{key}' not found in plugin configurations for type '{configType.Name}'.");
+            }
+            else
+            {
+                throw new KeyNotFoundException($"Plugin configuration for type '{configType.Name}' is not registered.");
+            }
+        }
+
+        public void SetAppSetting<T>(string key, T newValue)
+        {
+            lock (iolock)
+            {
+                object? oldValue = null;
+
+                if (this.appSettings.TryGetValue(key, out object? value))
+                {
+                    oldValue = value;
+
+                    try
+                    {
+                        T existingValue = value is T tValue
+                            ? tValue
+                            : (T)Convert.ChangeType(value, typeof(T));
+                        if (EqualityComparer<T>.Default.Equals(existingValue, newValue))
+                        {
+                            return;
+                        }
+                    }
+                    catch
+                    {
+                        // Ignore conversion errors, proceed to set new value
+                    }
+                }
+
+                this.appSettings[key] = newValue!;
+
+                AppSettingChanged?.Invoke(this,
+                    new ConfigServiceAppSettingChangeEventArgs(key, oldValue, newValue));
+            }
+        }
+        public void SetSetting<T>(Type configType, string key, T newValue, Token? token = null)
+        {
+            Token secToken = token ?? Token.Public;
+
+            lock (iolock)
+            {
+                if (!this.settings.TryGetValue(configType, out ConfigServiceSettings? settings))
+                {
+                    throw new InvalidOperationException("Plugin configuration not registered.");
+                }
+
+                this.tokenService.ValidateAccessor(settings.Write, secToken);
+                settings.UserSettings.TryGetValue(key, out object? oldValue);
+                object? baseValue = settings.BaseSettings.TryGetValue(key, out object? sysValue) ? sysValue : default;
+
+                if (oldValue == null && baseValue != null)
+                    oldValue = baseValue;
+
+                T? convertedSystemValue = default;
+                bool canCompare = false;
+                try
+                {
+                    if (baseValue != null)
+                    {
+                        convertedSystemValue = baseValue is T val ? val : (T)Convert.ChangeType(baseValue, typeof(T));
+
+                        canCompare = true;
+                    }
+                }
+                catch
+                {
+                    // Ignore conversion errors
+                }
+
+                if (canCompare && EqualityComparer<T>.Default.Equals(newValue, convertedSystemValue))
+                    settings.UserSettings.Remove(key);
+                else
+                    settings.UserSettings[key] = newValue!;
+
+                SettingChanged?.Invoke(this, new ConfigServiceSettingChangeEventArgs(configType, key, oldValue, newValue));
+            }
+        }
+
+        public async Task SaveAppSettingsAsync()
+        {
+            string appSettingsFilePath = Path.Combine(this.configRootDirectory, "appsettings.json");
+            try
+            {
+                await this.SaveToFileAsync(appSettingsFilePath, this.appSettings);
+            }
+            catch (Exception ex)
+            {
+                throw new IOException("Failed to save application settings.", ex);
+            }
+        }
+        public async Task SaveSettingsAsync(Type configType, Token? token = null)
+        {
+            Token secToken = token ?? Token.Public;
+
+            await aiolock.WaitAsync();
+            try
+            {
+                if (!this.settings.TryGetValue(configType, out ConfigServiceSettings? settings))
+                    throw new InvalidOperationException("Plugin configuration not registered.");
+
+                this.tokenService.ValidateAccessor(settings.Write, secToken);
+
+                string baseSettingsFilePath = this.GetSettingsPath(configType, true);
+                string userSettingsFilePath = this.GetSettingsPath(configType, false);
+
+                await this.SaveToFileAsync(baseSettingsFilePath, settings.BaseSettings);
+                await this.SaveToFileAsync(userSettingsFilePath, settings.UserSettings);
+            }
+            catch (Exception ex)
+            {
+                throw new IOException($"Failed to save settings for '{configType.Name}'.", ex);
+            }
+            finally
+            {
+                aiolock.Release();
+            }
+        }
+
+        public string GetBaseConfigFileContents(Type configType, Token? token = null)
+        {
+            Token secToken = token ?? Token.Public;
+
+            if (this.settings.TryGetValue(configType, out ConfigServiceSettings? settings))
+                this.tokenService.ValidateAccessor(settings.Read, secToken);
+
+            string settingPath = this.GetSettingsPath(configType, true);
+
+            if (!File.Exists(settingPath))
+                throw new FileNotFoundException($"Base config file not found: {settingPath}");
+
+            return File.ReadAllText(settingPath);
+        }
+        public string GetBaseConfigFileContents<TConfig>(Token? token = null) where TConfig : class
+            => this.GetBaseConfigFileContents(typeof(TConfig), token);
+
+        public async Task SaveBaseConfigFileContentsAsync(Type configType, string contents, Token? token = null)
+        {
+            Token secToken = token ?? Token.Public;
+
+            if (this.settings.TryGetValue(configType, out ConfigServiceSettings? settings))
+                this.tokenService.ValidateAccessor(settings.Write, secToken);
+
+            string settingPath = this.GetSettingsPath(configType, true);
+
+            try
+            {
+                if (!File.Exists(settingPath))
+                {
+                    string? settingDir = Path.GetDirectoryName(settingPath);
+
+                    if (settingDir != null)
+                        Directory.CreateDirectory(settingDir);
+                }
+
+                JsonDocument.Parse(contents);
+
+                string tempPath = System.IO.Path.GetTempFileName();
+                await File.WriteAllTextAsync(tempPath, contents);
+                File.Move(tempPath, settingPath, overwrite: true);
+            }
+            catch (IOException ex)
+            {
+                throw new IOException($"An I/O error occurred while trying to write to the file '{settingPath}'.", ex);
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                throw new UnauthorizedAccessException($"Access to the file '{settingPath}' is denied. Please check your permissions.", ex);
+            }
+            catch (JsonException ex)
+            {
+                throw new UnauthorizedAccessException($"Provided content failed to parse as JSON. Please check your contents.", ex);
+            }
+            catch (Exception ex)
+            {
+                throw new Exception($"An unexpected error occurred while saving the file '{settingPath}'.", ex);
+            }
+        }
+        public async Task SaveBaseConfigFileContentsAsync<TConfig>(string contents, Token? token = null) where TConfig : class
+            => await this.SaveBaseConfigFileContentsAsync(typeof(TConfig), contents, token);
+
+        public object GetConfigInstance(Type configType, Token? token = null)
+        {
+            Token secToken = token ?? Token.Public;
+
+            if (!this.settings.TryGetValue(configType, out ConfigServiceSettings? settingsEntry))
+                throw new KeyNotFoundException($"Configuration for type {configType.Name} not registered");
+
+            this.tokenService.ValidateAccessor(settingsEntry.Read, secToken);
+
+            string baseJson = this.GetBaseConfigFileContents(configType, token);
+
+            try
+            {
+                if (JsonSerializer.Deserialize(baseJson, configType, this.jsonOptions) is { } result)
+                    return result;
+
+                return Activator.CreateInstance(configType)
+                    ?? throw new InvalidOperationException($"Failed to create instance of {configType.Name}");
+            }
+            catch (JsonException ex)
+            {
+                this.logger.LogError(ex, $"Failed to deserialize {configType.Name}");
+                return Activator.CreateInstance(configType)
+                    ?? throw new InvalidOperationException($"Failed to create instance of {configType.Name}");
+            }
+        }
+        public void SaveConfigInstance(Type configType, object updatedConfig, Token? token = null)
+        {
+            if (updatedConfig == null)
+                throw new ArgumentNullException(nameof(updatedConfig));
+
+            foreach (var prop in configType.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+            {
+                if (!prop.CanRead || !prop.CanWrite) continue;
+                this.SetSetting(
+                    configType,
+                    prop.Name,
+                    prop.GetValue(updatedConfig),
+                    token
+                );
+            }
+        }
+
+        private void OnAppConfigChanged(object? state)
+        {
+            lock (iolock)
+            {
+                this.logger.LogInformation("App configuration has been reloaded.");
+
+                try
+                {
+                    this.LoadAppSettings();
+
+                    AppConfigReloaded?.Invoke(this, EventArgs.Empty);
+                }
+                catch (Exception ex)
+                {
+                    string messaage = $"Failed to reload application configuration";
+                    this.logger.LogError(ex, messaage);
+                    throw new InvalidOperationException(messaage, ex);
+                }
+                finally
+                {
+                    this.appConfig.GetReloadToken().RegisterChangeCallback(this.OnAppConfigChanged, null);
+                }
+            }
+        }
+        private void OnConfigChanged(object? state)
+        {
+            if (state == null) return;
+
+            Type configType = (Type)state;
+
+            lock (iolock)
+            {
+                this.logger.LogInformation("Plugin configuration for {PluginName} has been reloaded.", configType.Name);
+
+                if (this.configs.TryGetValue(configType, out ConfigServiceConfig? configs))
+                {
+                    Dictionary<string, object> baseSettings = [];
+                    Dictionary<string, object> userSettings = [];
+                    bool reloadSuccessful = false;
+
+                    try
+                    {
+                        LoadSettings(configs.BaseConfig, baseSettings);
+                        LoadSettings(configs.UserConfig, userSettings);
+                        reloadSuccessful = true;
+                    }
+                    catch (Exception ex)
+                    {
+                        string message = $"Error reloading settings for plugin {configType.Name}";
+                        this.logger.LogError(ex, message);
+                        throw new InvalidOperationException(message, ex);
+                    }
+                    finally
+                    {
+                        configs.BaseConfig.GetReloadToken()
+                            .RegisterChangeCallback(this.OnConfigChanged, configType);
+
+                        configs.UserConfig.GetReloadToken()
+                            .RegisterChangeCallback(this.OnConfigChanged, configType);
+                    }
+
+                    if (reloadSuccessful)
+                    {
+                        this.settings[configType] =
+                            new(baseSettings,
+                                userSettings,
+                                this.settings[configType].Read,
+                                this.settings[configType].Write);
+
+                        ConfigReloaded?.Invoke(this, new ConfigServiceConfigReloadedEventArgs(configType));
+                    }
+                }
+                else
+                {
+                    string message = $"Plugin configuration for type '{configType.Name}' is not registered.";
+                    this.logger.LogWarning(message);
+                    throw new KeyNotFoundException(message);
+                }
+            }
+        }
+
+        private void EnsureFileExists(string filePath, bool optional = false, Type? configType = null)
+        {
+            string? directory = System.IO.Path.GetDirectoryName(filePath);
+
+            if (directory != null && !Directory.Exists(directory))
+                Directory.CreateDirectory(directory);
+
+            if (!File.Exists(filePath))
+            {
+                if (!optional)
+                {
+                    try
+                    {
+                        string content = "{}";
+
+                        if (configType != null)
+                            content = configType.SerializeToJson(this.jsonOptions);
+
+                        File.WriteAllText(filePath, content);
+                    }
+                    catch (Exception ex)
+                    {
+                        throw new IOException($"Failed to create the required configuration file at '{filePath}'.", ex);
+                    }
+                }
+                else
+                {
+                    // Optional file does not exist, no action needed
+                }
+            }
+        }
+        private static IConfiguration BuildConfig(string filePath)
+        {
+            try
+            {
+                return new ConfigurationBuilder()
+                    .AddJsonFile(filePath, optional: true, reloadOnChange: true)
+                    .Build();
+            }
+            catch (Exception ex)
+            {
+                throw new IOException($"Failed to build configuration from file '{filePath}'.", ex);
+            }
+        }
+
+        private void LoadAppSettings()
+        {
+            lock (iolock)
+            {
+                this.appSettings.Clear();
+                try
+                {
+                    LoadSettings(this.appConfig, this.appSettings);
+                }
+                catch (Exception ex)
+                {
+                    throw new InvalidOperationException("Failed to load application settings from configuration.", ex);
+                }
+            }
+        }
+        private static void LoadSettings(IConfiguration config, Dictionary<string, object> settings)
+        {
+            try
+            {
+                foreach (IConfigurationSection section in config.GetChildren())
+                {
+                    settings[section.Key] = section.Value!;
+
+                    LoadSettings(section, settings);
+                }
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidOperationException("Failed to load settings from configuration.", ex);
+            }
+        }
+
+        private string GetSettingsPath(Type configType, bool baseFile)
+        {
+            if (baseFile)
+                return Path.Combine(this.configRootDirectory, configFolderPath, $"{configType.Name}.BaseSettings.json");
+            else
+                return Path.Combine(this.configUserDirectory, configFolderPath, $"{configType.Name}.UserSettings.json");
+        }
+        private async Task SaveToFileAsync(string filePath, Dictionary<string, object> settings)
+        {
+            try
+            {
+                string tempPath = System.IO.Path.GetTempFileName();
+                await File.WriteAllTextAsync(tempPath, JsonSerializer.Serialize(settings, this.jsonOptions));
+                File.Move(tempPath, filePath, overwrite: true);
+            }
+            catch (IOException ex)
+            {
+                throw new IOException($"An I/O error occurred while trying to write to the file '{filePath}'.", ex);
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                throw new UnauthorizedAccessException($"Access to the file '{filePath}' is denied. Please check your permissions.", ex);
+            }
+            catch (JsonException ex)
+            {
+                throw new JsonException($"An error occurred during JSON serialization for the file '{filePath}'.", ex);
+            }
+            catch (Exception ex)
+            {
+                throw new Exception($"An unexpected error occurred while saving the file '{filePath}'.", ex);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Title  
Configure Dependency Injection and Register Core Services as Singleton  

## Description  
This pull request introduces a secure, centralized configuration management system through the implementation of ConfigService and ConfigAccessor. ConfigService manages application settings with validation and persistence, while ConfigAccessor enforces token-based access control to ensure only authorized operations are permitted. Both services are registered as singletons in the dependency injection container, and their functionality is thoroughly validated by comprehensive unit tests.  
- Added `ConfigService` implementation for configuration management  
- Added `ConfigAccessor` for secure configuration access  
- Registered both services as singletons in DI container  
- Added comprehensive unit tests for both components  

## Related Issue  
- Resolves #11  
- Resolves #7  

## Motivation and Context  
These changes enable secure, centralized configuration management for PlugHub Desktop. The implementation:  
1. Provides a robust configuration management system (`ConfigService`)  
2. Implements secure access patterns through `ConfigAccessor`  
3. Ensures single-instance service availability via DI registration  

## How Has This Been Tested?  
- Added 47 unit tests covering all public methods of `ConfigService` and `ConfigAccessor`  
- Tests validate:  
  - Configuration loading/saving  
  - Access control enforcement  
  - Error handling for invalid operations  
  - Token-based permission verification  

## Screenshots (if appropriate):  
*Not applicable - backend service implementation*  

## Types of changes  
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Asset change (adds or updates icons, templates, or other assets)
- [ ] Documentation change (adds or updates documentation)
- [ ] Plugin change (adds or updates a plugin)

## Checklist:  
- [x] I have read the **CONTRIBUTING** document.  
- [x] My change requires a change to the core logic.  
    - [x] I have linked the project issue above.
- [ ] My change requires a change to the assets.  
    - [ ] I have linked the asset issue above.  
- [ ] My change requires a change to the documentation.  
    - [ ] I have linked the documentation issue above.   
- [ ] My change requires a change to a plugin.  
    - [ ] I have linked the plugin issue above. 
