### PR TITLE
Workflow enabled `pull-requests`

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -11,6 +11,7 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   test:


### PR DESCRIPTION
## Description
Adds a `workflow_dispatch` trigger to the **pull-request**  CI workflow under `.github/workflows/`.  
Maintainers can now click the “Run workflow” button (or use `gh workflow run`) to kick off a test job without pushing a commit.

## Related Issue
Resolves #15

## Motivation and Context
Re-running CI is occasionally necessary after:
* rotating repository secrets  
* testing out of branches
* transient third-party outages

Manual triggering keeps git history clean and removes the need for empty “rebuild” commits.

## How Has This Been Tested?
—  
(workflow will be exercised on this PR once merged)

## Screenshots (if appropriate):
—  

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Asset change (adds or updates icons, templates, or other assets)
- [ ] Documentation change (adds or updates documentation)
- [ ] Plugin change (adds or updates a plugin)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My change requires a change to the core logic.
    - [x] I have linked the project issue above.
- [ ] My change requires a change to the assets.
    - [ ] I have linked the asset issue above.
- [ ] My change requires a change to the documentation.
    - [ ] I have linked the documentation issue above.
- [ ] My change requires a change to a plugin.
    - [ ] I have linked the plugin issue above.