### PR TITLE
Fixes TokenService constructor takes ILogger<TokenService> instead of ILogger<ITokenService>

### DIFF
--- a/PlugHub.UnitTests/Services/TokenServiceTests.cs
+++ b/PlugHub.UnitTests/Services/TokenServiceTests.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.Logging;
 using Moq;
 using PlugHub.Services;
+using PlugHub.Shared.Interfaces.Services;
 using PlugHub.Shared.Models;
 
 namespace PlugHub.UnitTests.Services
@@ -8,13 +9,13 @@ namespace PlugHub.UnitTests.Services
     [TestClass]
     public class TokenServiceTests
     {
-        private Mock<ILogger<TokenService>>? loggerMock;
+        private Mock<ILogger<ITokenService>>? loggerMock;
         private TokenService? tokenService;
 
         [TestInitialize]
         public void Setup()
         {
-            this.loggerMock = new Mock<ILogger<TokenService>>();
+            this.loggerMock = new Mock<ILogger<ITokenService>>();
             this.tokenService = new TokenService(this.loggerMock.Object);
         }
 
@@ -31,7 +32,7 @@ namespace PlugHub.UnitTests.Services
         }
 
         [TestMethod]
-        public void ValidateAccessorPublicSourcePublicAccessorReturnsTrue()
+        public void ValidateAccessor_PublicSource_PublicAccessorReturnsTrue()
         {
             // Arrange
             Token source = Token.Public;
@@ -45,7 +46,7 @@ namespace PlugHub.UnitTests.Services
         }
 
         [TestMethod]
-        public void ValidateAccessorBlockedSourceAnyAccessorThrowsException()
+        public void ValidateAccessor_BlockedSourceAnyAccessor_ThrowsException()
         {
             // Arrange
             Token source = Token.Blocked;
@@ -57,11 +58,11 @@ namespace PlugHub.UnitTests.Services
         }
 
         [TestMethod]
-        public void ValidateAccessorCustomTokenValidAccessorReturnsTrue()
+        public void ValidateAccessor_CustomTokenValidAccessor_ReturnsTrue()
         {
             // Arrange
             Token source = Token.New();
-            Token accessor = source; // Same token
+            Token accessor = source;
 
             // Act
             bool result = this.tokenService!.ValidateAccessor(source, accessor);
@@ -71,11 +72,11 @@ namespace PlugHub.UnitTests.Services
         }
 
         [TestMethod]
-        public void ValidateAccessorCustomTokenInvalidAccessorThrowsException()
+        public void ValidateAccessor_CustomTokenInvalidAccessor_ThrowsException()
         {
             // Arrange
             Token source = Token.New();
-            Token accessor = Token.New(); // Different token
+            Token accessor = Token.New();
 
             // Act & Assert
             Assert.ThrowsException<UnauthorizedAccessException>(
@@ -83,7 +84,7 @@ namespace PlugHub.UnitTests.Services
         }
 
         [TestMethod]
-        public void ValidateAccessorPublicSourceBlockedAccessorThrowsException()
+        public void ValidateAccessor_PublicSourceBlockedAccessor_ThrowsException()
         {
             // Arrange
             Token source = Token.Blocked;
@@ -95,11 +96,11 @@ namespace PlugHub.UnitTests.Services
         }
 
         [TestMethod]
-        public void ValidateAccessorNonThrowingModeReturnsFalseForInvalid()
+        public void ValidateAccessor_NonThrowingModeReturnsFalseForInvalid()
         {
             // Arrange
             Token source = Token.New();
-            Token accessor = Token.New(); // Different token
+            Token accessor = Token.New();
 
             // Act
             bool result = this.tokenService!.ValidateAccessor(source, accessor, false);
@@ -109,7 +110,7 @@ namespace PlugHub.UnitTests.Services
         }
 
         [TestMethod]
-        public void ValidateAccessorSameTokenDifferentInstancesReturnsTrue()
+        public void ValidateAccessor_SameTokenDifferentInstances_ReturnsTrue()
         {
             // Arrange
             Guid tokenId = Guid.NewGuid();
@@ -124,7 +125,7 @@ namespace PlugHub.UnitTests.Services
         }
 
         [TestMethod]
-        public void TokenImplicitConversionReturnsCorrectGuid()
+        public void Token_ImplicitConversion_ReturnsCorrectGuid()
         {
             // Arrange
             Guid expected = Guid.NewGuid();

--- a/PlugHub/App.axaml.cs
+++ b/PlugHub/App.axaml.cs
@@ -7,11 +7,9 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using PlugHub.Services;
 using PlugHub.Shared.Interfaces.Services;
-using PlugHub.Shared.Models;
 using PlugHub.ViewModels;
 using PlugHub.Views;
 using System;
-using System.IO;
 using System.Linq;
 
 namespace PlugHub;
@@ -65,12 +63,8 @@ public partial class App : Application
 
     private static void ConfigureGlobalServices(IServiceCollection services)
     {
-        services.AddSingleton<ITokenService>(provider =>
-        {
-            ILogger<TokenService> logger = logger = new NullLogger<TokenService>();
-
-            return new TokenService(logger);
-        });
+        services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
+        services.AddSingleton<ITokenService, TokenService>();
     }
 
     private static void DisableAvaloniaDataAnnotationValidation()

--- a/PlugHub/Services/TokenService.cs
+++ b/PlugHub/Services/TokenService.cs
@@ -5,9 +5,9 @@ using System;
 
 namespace PlugHub.Services
 {
-    public class TokenService(ILogger<TokenService> logger) : ITokenService
+    public class TokenService(ILogger<ITokenService> logger) : ITokenService
     {
-        private readonly ILogger<TokenService> logger = logger;
+        private readonly ILogger<ITokenService> logger = logger;
 
         public Token CreateToken()
         {


### PR DESCRIPTION
## Description
TokenService now depends on `ILogger<ITokenService>` instead of `ILogger<TokenService>`.

Concrete changes (see ITokenDiff.txt):
* `TokenService` constructor and backing field switched to `ILogger<ITokenService>`.
* DI registration simplified to `services.AddSingleton<ITokenService, TokenService>();`.
* Unit tests updated to mock `ILogger<ITokenService>`.

This aligns TokenService with the project guideline “constructor dependencies use the interface generic”, making DI resolution and mocking consistent across services.

## Related Issue
Fixes #14

## Motivation and Context
The previous constructor required callers/tests to register `ILogger<TokenService>`, breaking the abstraction pattern and causing DI resolution failures in isolated test projects.
Switching to the interface generic restores consistency and removes the need for duplicate logger registrations.

## How Has This Been Tested?
* Updated `TokenServiceTests` compile and pass.  
* Ran full `PlugHub.UnitTests` suite on .NET 8 (Windows, macOS). All green.  
* Manual smoke-test: application starts and resolves `ITokenService` via the updated DI registration.

## Screenshots (if appropriate):
—

## Types of changes

- [x] Bug fix 
- [ ] New feature
- [ ] Breaking change
- [ ] Asset change
- [ ] Documentation change
- [ ] Plugin change

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My change requires a change to the core logic.  
    - [x] I have linked the project issue above.
- [ ] My change requires a change to the assets.
    - [ ] I have linked the asset issue above.
- [ ] My change requires a change to the documentation.
    - [ ] I have linked the documentation issue above.
- [ ] My change requires a change to a plugin.
    - [ ] I have linked the plugin issue above.
