### PR TITLE
Adds TokenSet and simplifies Token model

### DIFF
--- a/PlugHub.Shared/Interfaces/Models/ITokenSet.cs
+++ b/PlugHub.Shared/Interfaces/Models/ITokenSet.cs
@@ -1,0 +1,27 @@
+﻿using PlugHub.Shared.Models;
+
+namespace PlugHub.Shared.Interfaces.Models
+{
+    /// <summary>
+    /// Represents a set of access tokens.
+    /// </summary>
+    public interface ITokenSet
+    {
+        /// <summary>
+        /// Gets the <see cref="Token"/> used for read access.
+        /// </summary>
+        Token Read { get; }
+
+        /// <summary>
+        /// Gets the <see cref="Token"/> used for write access.
+        /// </summary>
+        Token Write { get; }
+
+        /// <summary>
+        /// Deconstructs the token set into its individual <see cref="Token"/> components.
+        /// </summary>
+        /// <param name="read">The read access <see cref="Token"/>.</param>
+        /// <param name="write">The write access <see cref="Token"/>.</param>
+        void Deconstruct(out Token read, out Token write);
+    }
+}

--- a/PlugHub.Shared/Interfaces/Services/ITokenService.cs
+++ b/PlugHub.Shared/Interfaces/Services/ITokenService.cs
@@ -1,9 +1,10 @@
-﻿using PlugHub.Shared.Models;
+﻿using PlugHub.Shared.Interfaces.Models;
+using PlugHub.Shared.Models;
 
 namespace PlugHub.Shared.Interfaces.Services
 {
     /// <summary>
-    /// Defines methods for creating and validating tokens within the PlugHub system.
+    /// Defines methods for creating and validating access permission tokens within the PlugHub system.
     /// </summary>
     public interface ITokenService
     {
@@ -16,20 +17,37 @@ namespace PlugHub.Shared.Interfaces.Services
         public Token CreateToken();
 
         /// <summary>
-        /// Validates whether the accessor token is authorized to access the source token.
+        /// Validates whether the accessor is authorized to access the source.
         /// </summary>
-        /// <param name="source">
-        /// The original <see cref="Token"/> to be accessed.
-        /// </param>
-        /// <param name="accessor">
-        /// The <see cref="Token"/> attempting to access the source.
-        /// </param>
-        /// <param name="throwException">
-        /// If <c>true</c>, throws an exception when validation fails; otherwise, returns <c>false</c>.
-        /// </param>
+        /// <param name="source">The original <see cref="Token"/> to be accessed.</param>
+        /// <param name="accessor">The <see cref="Token"/> attempting to access the source.</param>
+        /// <param name="throwException">If <c>true</c>, throws an exception when validation fails; otherwise, returns <c>false</c>.</param> 
         /// <returns>
         /// <c>true</c> if the accessor token is valid for the source; otherwise, <c>false</c>.
         /// </returns>
-        public bool ValidateAccessor(Token source, Token accessor, bool throwException = true);
+        public bool AllowAccess(Token source, Token accessor, bool throwException = true);
+
+        /// <summary>
+        /// Creates a new <see cref="ITokenSet"/> with optional read and write <see cref="Token"/>s.
+        /// </summary>
+        /// <param name="read">An optional <see cref="Token"/> granting read access.</param>
+        /// <param name="write">An optional <see cref="Token"/> granting write access.</param>
+        /// <returns>
+        /// An <see cref="ITokenSet"/> containing the specified tokens.
+        /// </returns>
+        public ITokenSet CreateTokenSet(Token? read = null, Token? write = null);
+
+        /// <summary>
+        /// Determines if any token in the provided set satisfies the requirements of the required set.
+        /// </summary>
+        /// <param name="required">The set of tokens required for access.</param>
+        /// <param name="provided">The set of tokens presented for validation.</param>
+        /// <param name="throwIfInvalid">
+        /// If <c>true</c>, throws an exception when validation fails; otherwise, returns <c>false</c>.
+        /// </param>
+        /// <returns>
+        /// <c>true</c> if any provided token meets the required access; otherwise, <c>false</c>.
+        /// </returns>
+        bool AllowAny(ITokenSet required, ITokenSet provided, bool throwIfInvalid = true);
     }
 }

--- a/PlugHub.Shared/Models/Token.cs
+++ b/PlugHub.Shared/Models/Token.cs
@@ -1,7 +1,7 @@
 ﻿namespace PlugHub.Shared.Models
 {
     /// <summary>
-    /// Represents an immutable security token, backed by a <see cref="Guid"/>, used for access control and identification.
+    /// Represents an immutable security token, backed by a <see cref="Guid"/>, used for access control.
     /// </summary>
     public readonly struct Token : IEquatable<Token>
     {

--- a/PlugHub/Models/TokenSet.cs
+++ b/PlugHub/Models/TokenSet.cs
@@ -1,0 +1,14 @@
+﻿using PlugHub.Shared.Interfaces.Models;
+using PlugHub.Shared.Models;
+
+namespace PlugHub.Models
+{
+    public readonly record struct TokenSet(Token Read, Token Write) : ITokenSet
+    {
+        public readonly void Deconstruct(out Token read, out Token write)
+        {
+            read = this.Read;
+            write = this.Write;
+        }
+    }
+}

--- a/PlugHub/Services/TokenService.cs
+++ b/PlugHub/Services/TokenService.cs
@@ -1,4 +1,6 @@
 ﻿using Microsoft.Extensions.Logging;
+using PlugHub.Models;
+using PlugHub.Shared.Interfaces.Models;
 using PlugHub.Shared.Interfaces.Services;
 using PlugHub.Shared.Models;
 using System;
@@ -10,20 +12,39 @@ namespace PlugHub.Services
         private readonly ILogger<ITokenService> logger = logger;
 
         public Token CreateToken()
+            => Token.New();
+
+        public ITokenSet CreateTokenSet(Token? read = null, Token? write = null)
         {
-            Token token = Token.New();
-            return token;
+            var secRead = read ?? write ?? Token.Public;
+            var secWrite = write ?? Token.Blocked;
+
+            return new TokenSet(secRead, secWrite);
         }
 
-        public bool ValidateAccessor(Token source, Token accessor, bool throwException = true)
+        public bool AllowAccess(Token source, Token accessor, bool throwException = true)
         {
             if (source != Token.Blocked && (source == Token.Public || source == accessor))
                 return true;
 
             if (throwException)
-                throw new UnauthorizedAccessException($"Proivded token is invalid.");
+                ThrowUniformException();
 
             return false;
         }
+
+        public bool AllowAny(ITokenSet required, ITokenSet provided, bool throwIfInvalid = true)
+        {
+            if (this.AllowAccess(required.Read, provided.Read, false) || this.AllowAccess(required.Write, provided.Write, false))
+                return true;
+
+            if (throwIfInvalid)
+                ThrowUniformException();
+
+            return false;
+        }
+
+        private static void ThrowUniformException()
+            => throw new UnauthorizedAccessException($"Proivded token is invalid.");
     }
 }


### PR DESCRIPTION
## Description
This PR introduces a first-class `TokenSet` abstraction and centralizes token normalization and permission logic across the codebase.  
- Adds an immutable `TokenSet` (as a record struct) representing a pair of access tokens (`Read` and `Write`).
- Updates the `ITokenService` interface to include `CreateTokenSet`, which constructs a normalized `TokenSet` using clear, consistent defaults (`Read` defaults to `Token.Public` or inherits from `Write`; `Write` defaults to `Token.Blocked`).
- Adds `AllowAny` to `ITokenService` for validating if any provided token in a set meets the required permission.
- Renames `ValidateAccessor` to `AllowAccess` and updates all usage and comments to clarify the focus on access rather than authorization.
- Refines token documentation and exception handling for clarity and consistency.
- Expands and reorganizes unit tests to cover new behaviors, normalization rules, and edge cases.

## Related Issue
resolves #18

## Motivation and Context
This change reduces duplication and ambiguity in token handling by providing a single, reusable API for generating and validating permission sets.  
- Ensures every layer (config, data, UI, etc.) applies the same normalization rules.
- Makes intent explicit and future policy changes easier to implement.
- Improves security by defaulting write tokens to `Blocked`.

## How Has This Been Tested?
- Comprehensive unit tests added for `TokenSet` creation, normalization, and validation logic.
- Tests cover default and custom scenarios, edge cases, and strict equality/hash semantics.
- All existing tests updated to use the new methods and naming.
- Tests run in a .NET 8 environment with `NullLogger` for isolation.

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Asset change (adds or updates icons, templates, or other assets)
- [ ] Documentation change (adds or updates documentation)
- [ ] Plugin change (adds or updates a plugin)

## Checklist:


- [ ] I have read the **CONTRIBUTING** document.
- [x] My change requires a change to the core logic.
    - [x] I have linked the project issue above.
- [ ] My change requires a change to the assets.
    - [ ] I have linked the asset issue above.
- [ ] My change requires a change to the documentation.
    - [ ] I have linked the documentation issue above.
- [ ] My change requires a change to a plugin.
    - [ ] I have linked the plugin issue above.