### PR TITLE
Implemented ConfigService for Secure Configuration Management

### DIFF
--- a/PlugHub.Shared/Extensions/TypeExtensions.cs
+++ b/PlugHub.Shared/Extensions/TypeExtensions.cs
@@ -1,0 +1,20 @@
+﻿using System.Text.Json;
+
+namespace PlugHub.Shared.Extensions
+{
+    public static class TypeExtensions
+    {
+        /// <summary>
+        /// Serializes a new instance of the given type (using its parameterless constructor) to JSON.
+        /// </summary>
+        public static string SerializeToJson(this Type type, JsonSerializerOptions? options = null)
+        {
+            if (type.GetConstructor(Type.EmptyTypes) == null)
+                throw new InvalidOperationException($"{type.Name} requires a parameterless constructor for default initialization");
+
+            object instance = Activator.CreateInstance(type)!;
+            return JsonSerializer.Serialize(instance, options ?? new JsonSerializerOptions { WriteIndented = true });
+        }
+    }
+
+}

--- a/PlugHub.Shared/Interfaces/Accessors/IConfigAccessor.cs
+++ b/PlugHub.Shared/Interfaces/Accessors/IConfigAccessor.cs
@@ -1,0 +1,115 @@
+﻿using PlugHub.Shared.Interfaces.Services;
+
+namespace PlugHub.Shared.Interfaces.Accessors
+{
+    /// <summary>
+    /// Root entry-point into PlugHub’s configuration system.
+    /// </summary>
+    /// <remarks>
+    /// Call <see cref="For{TConfig}"/> to obtain an accessor that is specialised for a single
+    /// configuration POCO.  From that accessor you can read, mutate, and persist configuration
+    /// values while PlugHub handles default/user merge-logic, RBAC, and—in the secure pipeline—
+    /// automatic encryption.
+    /// </remarks>
+    public interface IConfigAccessor
+    {
+        /// <summary>
+        /// Returns a strongly-typed accessor for configuration section
+        /// <typeparamref name="TConfig"/>.
+        /// </summary>
+        /// <typeparam name="TConfig">
+        /// Class that models a configuration section (must be public and have a parameterless constructor).
+        /// </typeparam>
+        /// <returns>
+        /// An <see cref="IConfigAccessorFor{TConfig}"/> instance through which the caller can
+        /// <see cref="IConfigAccessorFor{TConfig}.Get{T}(string)"/> / 
+        /// <see cref="IConfigAccessorFor{TConfig}.Set{T}(string,T)"/> individual keys,
+        /// or load / save an entire <typeparamref name="TConfig"/> object.
+        /// </returns>
+        /// <exception cref="ConfigTypeNotFoundException">
+        /// Thrown when <typeparamref name="TConfig"/> has not been registered with the
+        /// configuration service.
+        /// </exception>
+        IConfigAccessorFor<TConfig> For<TConfig>() where TConfig : class;
+    }
+
+    /// <summary>
+    /// Provides fine-grained, type-safe access to a single configuration class of type <typeparamref name="TConfig"/>.
+    /// Supports key-level reads/writes with compile-time type validation and whole-object operations
+    /// including retrieval, merging, and persistence. Includes synchronous and asynchronous save methods.
+    /// </summary>
+    /// <typeparam name="TConfig">The POCO representing the configuration section</typeparam>
+    public interface IConfigAccessorFor<TConfig> where TConfig : class
+    {
+        /// <summary>
+        /// Fetches the current *effective* value for <paramref name="key"/> and converts it
+        /// to <typeparamref name="T"/>.
+        /// </summary>
+        /// <typeparam name="T">Desired return type.</typeparam>
+        /// <param name="key">Public property name on <typeparamref name="TConfig"/>.</param>
+        /// <returns>The merged (user ⮕ default) value converted to <typeparamref name="T"/>.</returns>
+        /// <exception cref="KeyNotFoundException">
+        /// Thrown when the property does not exist in <typeparamref name="TConfig"/>.
+        /// </exception>
+        T Get<T>(string key);
+
+        /// <summary>
+        /// Assigns <paramref name="value"/> to <paramref name="key"/> in memory.
+        /// </summary>
+        /// <remarks>
+        /// The change is *not* flushed to disk until one of the <c>Save*</c> methods is
+        /// invoked.  For secure properties the value is encrypted automatically before it
+        /// leaves the accessor.
+        /// </remarks>
+        /// <typeparam name="T">Type of the value being stored.</typeparam>
+        /// <param name="key">Public property name on <typeparamref name="TConfig"/>.</param>
+        void Set<T>(string key, T value);
+
+        /// <summary>
+        /// Synchronously writes all pending per-key edits to the user-scope configuration
+        /// file.  
+        /// Only keys whose value differs from the default are written, so the file contains
+        /// nothing but user overrides.
+        /// </summary>
+        /// <remarks>Blocks the calling thread for the duration of the file I/O.</remarks>
+        void Save();
+
+        /// <summary>
+        /// Asynchronous counterpart of <see cref="Save"/>.  
+        /// Use this in UI or high-throughput code paths to avoid blocking.
+        /// </summary>
+        Task SaveAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Builds and returns the fully merged <typeparamref name="TConfig"/> instance that
+        /// the current caller would observe—i.e. <c>user&nbsp;overrides&nbsp;⇾&nbsp;default</c>.
+        /// </summary>
+        TConfig Get();
+
+        /// <summary>
+        /// Writes every property of <paramref name="config"/> to the user configuration
+        /// file using PlugHub’s merge rules.
+        /// </summary>
+        /// <param name="config">Fully populated configuration object.</param>
+        /// <remarks>
+        /// <list type="bullet">
+        ///   <item><description>
+        ///     Properties whose value equals the default are **omitted** (existing overrides
+        ///     are removed).
+        ///   </description></item>
+        ///   <item><description>
+        ///     Properties flagged as secure are persisted as encrypted Base-64 strings.
+        ///   </description></item>
+        /// </list>
+        /// This synchronous overload blocks until the write is complete; use
+        /// <see cref="SaveAsync(TConfig)"/> to perform the same operation asynchronously.
+        /// </remarks>
+        void Save(TConfig config);
+
+        /// <summary>
+        /// Asynchronous variant of <see cref="Save(TConfig)"/> that performs the comparison,
+        /// optional encryption, and disk write without blocking the calling thread.
+        /// </summary>
+        Task SaveAsync(TConfig config, CancellationToken cancellationToken = default);
+    }
+}

--- a/PlugHub.Shared/Interfaces/Services/IConfigService.cs
+++ b/PlugHub.Shared/Interfaces/Services/IConfigService.cs
@@ -1,0 +1,605 @@
+﻿using Microsoft.Extensions.Configuration;
+using PlugHub.Shared.Interfaces.Accessors;
+using PlugHub.Shared.Interfaces.Models;
+using PlugHub.Shared.Models;
+using System.Text.Json;
+
+namespace PlugHub.Shared.Interfaces.Services
+{
+    /// <summary>
+    /// Exception thrown when a requested type config is not registered in the config service.
+    /// </summary>
+    /// <remarks>
+    /// Inherits from <see cref="KeyNotFoundException"/> to indicate that the requested type could not be found
+    /// in the underlying collection of config.
+    /// </remarks>
+    /// <remarks>
+    /// Initializes a new instance of the <see cref="ConfigTypeNotFoundException"/> class
+    /// with a message indicating the missing type.
+    /// </remarks>
+    /// <param name="type">The <see cref="Type"/> for which the config was not registered.</param>
+    public class ConfigTypeNotFoundException(string? message) : KeyNotFoundException(message) { }
+
+
+    /// <summary>
+    /// Enumerates the types of configuration operations that can trigger a fire-and-forget save error.
+    /// </summary>
+    public enum ConfigSaveOperation
+    {
+        /// <summary>
+        /// The operation is unknown or unspecified.
+        /// </summary>
+        Unknown,
+
+        /// <summary>
+        /// Represents a save operation for configuration settings.
+        /// </summary>
+        SaveSettings,
+
+        /// <summary>
+        /// Represents a save operation for an entire configuration instance.
+        /// </summary>
+        SaveConfigInstance,
+
+        /// <summary>
+        /// Represents a save operation for default configuration file contents.
+        /// </summary>
+        SaveDefaultConfigFileContents
+    }
+
+    /// <summary>
+    /// Provides data for the <c>ConfigService.SyncSaveOpErrors</c> event,
+    /// containing details about a fire-and-forget save error in the configuration service.
+    /// </summary>
+    /// <param name="ex">The exception that was thrown during the operation.</param>
+    /// <param name="operation">The type of configuration operation that failed.</param>
+    /// <param name="configType">The configuration type involved in the operation, if applicable.</param>
+    public class ConfigServiceSaveErrorEventArgs(Exception ex, ConfigSaveOperation operation = ConfigSaveOperation.Unknown, Type? configType = null) : EventArgs
+    {
+        /// <summary>
+        /// Gets the exception that was thrown during the configuration save operation.
+        /// </summary>
+        public Exception Exception = ex;
+
+        /// <summary>
+        /// Gets the type of configuration operation that failed.
+        /// </summary>
+        public ConfigSaveOperation Operation = operation;
+
+        /// <summary>
+        /// Gets the configuration type involved in the operation, if applicable.
+        /// </summary>
+        public Type? ConfigType = configType;
+    }
+
+
+    /// <summary>
+    /// Event arguments for when a configuration file is reloaded in the <see cref="ConfigService"/>.
+    /// Provides the type of the configuration that was reloaded.
+    /// </summary>
+    /// <param name="configType">The configuration type that was reloaded.</param>
+    public class ConfigServiceConfigReloadedEventArgs(Type configType) : EventArgs
+    {
+        /// <summary>
+        /// Gets the configuration type that was reloaded.
+        /// </summary>
+        public Type ConfigType { get; } = configType;
+    }
+
+    /// <summary>
+    /// Event arguments for when a default or user setting changes in the <see cref="ConfigService"/>.
+    /// Provides the configuration type, key, and both the old and new values of the setting.
+    /// </summary>
+    /// <param name="configType">The configuration type where the setting changed.</param>
+    /// <param name="key">The key of the setting that changed.</param>
+    /// <param name="oldValue">The previous value of the setting.</param>
+    /// <param name="newValue">The new value of the setting.</param>
+    public class ConfigServiceSettingChangeEventArgs(Type configType, string key, object? oldValue, object? newValue) : EventArgs
+    {
+        /// <summary>
+        /// Gets the configuration type where the setting changed.
+        /// </summary>
+        public Type ConfigType { get; } = configType;
+
+        /// <summary>
+        /// Gets the key of the setting that changed.
+        /// </summary>
+        public string Key { get; } = key;
+
+        /// <summary>
+        /// Gets the previous value of the setting.
+        /// </summary>
+        public object? OldValue { get; } = oldValue;
+
+        /// <summary>
+        /// Gets the new value of the setting.
+        /// </summary>
+        public object? NewValue { get; } = newValue;
+    }
+
+
+    /// <summary>
+    /// Provides methods for managing application and type-defaultd configuration settings.
+    /// </summary>
+    public interface IConfigService
+    {
+        /// <summary>
+        /// Occurs when a fire-and-forget save operation in <see cref="ConfigService"/> fails.
+        /// </summary>
+        public event EventHandler<ConfigServiceSaveErrorEventArgs>? SyncSaveOpErrors;
+
+        /// <summary>
+        /// Occurs when a configuration file is reloaded from disk (for example, due to an external file change).
+        /// </summary>
+        public event EventHandler<ConfigServiceConfigReloadedEventArgs>? ConfigReloaded;
+
+        /// <summary>
+        /// Occurs when a type-specific configuration value is changed via <see cref="SetSetting{T}(Type, string, T, bool)"/>.
+        /// </summary>
+        public event EventHandler<ConfigServiceSettingChangeEventArgs>? SettingChanged;
+
+
+        /// <summary>
+        /// Creates an <see cref="IConfigAccessor"/> for a single configuration type,
+        /// using dedicated tokens for access control operations.
+        /// </summary>
+        /// <param name="configType">The configuration type to access.</param>
+        /// <param name="ownerToken">Optional token for owner operations. Defaults to a new <see cref="Token"/> if not specified.</param>
+        /// <param name="readToken">Optional token for read operations. Defaults to <see cref="Token.Public"/> if not specified.</param>
+        /// <param name="writeToken">Optional token for write operations. Defaults to <see cref="Token.Blocked"/> if not specified.</param>
+        /// <returns>
+        /// An <see cref="IConfigAccessor"/> scoped to the specified type and tokens.
+        /// </returns>
+        public IConfigAccessor CreateAccessor(Type configType, Token? ownerToken = null, Token? readToken = null, Token? writeToken = null);
+
+        /// <summary>
+        /// Creates an <see cref="IConfigAccessor"/> for a single configuration type,
+        /// using dedicated tokens for access control operations.
+        /// </summary>
+        /// <param name="configType">The configuration type to access.</param>
+        /// <param name="tokenSet">Consolidated token container for owner/read/write permissions.</param>
+        /// <returns>
+        /// An <see cref="IConfigAccessor"/> scoped to the specified type and tokens.
+        /// </returns>
+        public IConfigAccessor CreateAccessor(Type configType, ITokenSet tokenSet);
+
+
+        /// <summary>
+        /// Creates an <see cref="IConfigAccessor"/> for multiple configuration types,
+        /// using the specified tokens for access control.
+        /// </summary>
+        /// <param name="configTypes">The configuration types to access.</param>
+        /// <param name="ownerToken">Optional token for owner operations. Defaults to a new <see cref="Token"/> if not specified.</param>
+        /// <param name="readToken">Optional token for read operations. Defaults to <see cref="Token.Public"/> if not specified.</param>
+        /// <param name="writeToken">Optional token for write operations. Defaults to <see cref="Token.Blocked"/> if not specified.</param>
+        /// <returns>
+        /// An <see cref="IConfigAccessor"/> scoped to the specified types and tokens.
+        /// </returns>
+        public IConfigAccessor CreateAccessor(IList<Type> configTypes, Token? ownerToken = null, Token? readToken = null, Token? writeToken = null);
+
+        /// <summary>
+        /// Creates an <see cref="IConfigAccessor"/> for multiple configuration types,
+        /// using the specified tokens for access control.
+        /// </summary>
+        /// <param name="configTypes">The configuration types to access.</param>
+        /// <param name="tokenSet">Consolidated token container for owner/read/write permissions.</param>
+        /// <returns>
+        /// An <see cref="IConfigAccessor"/> scoped to the specified types and tokens.
+        /// </returns>
+        public IConfigAccessor CreateAccessor(IList<Type> configTypes, ITokenSet tokenSet);
+
+
+        /// <summary>
+        /// Registers a configuration type with granular token-based access control and type-specific JSON serialization settings.
+        /// </summary>
+        /// <param name="configType">The type representing the configuration.</param>
+        /// <param name="ownerToken">Optional token for owner operations. Defaults to a new <see cref="Token"/> if not specified.</param>
+        /// <param name="readToken">Optional token for read operations. Defaults to <see cref="Token.Public"/> if not specified.</param>
+        /// <param name="writeToken">Optional token for write operations. Defaults to <see cref="Token.Blocked"/> if not specified.</param>
+        /// <param name="jsonOptions">Specifies custom JSON serialization settings for this configuration type, allowing fine-grained control over property naming, converters, and formatting. Overrides global JSON options for this type.</param>
+        /// <param name="reloadOnChange">If true, automatically reloads configuration when source changes.</param>
+        /// <exception cref="UnauthorizedAccessException"/>
+        public void RegisterConfig(Type configType, Token? ownerToken = null, Token? readToken = null, Token? writeToken = null, JsonSerializerOptions? jsonOptions = null, bool reloadOnChange = false);
+
+        /// <summary>
+        /// Registers a configuration type using a token set for consolidated access control,
+        /// with type-specific JSON serialization settings and change reloading.
+        /// </summary>
+        /// <param name="configType">The type representing the configuration structure.</param>
+        /// <param name="tokenSet">Consolidated token container for owner/read/write permissions.</param>
+        /// <param name="jsonOptions">Custom JSON serialization settings for this configuration type, overriding global options for property naming, converters, and formatting.</param>
+        /// <param name="reloadOnChange">Enables automatic reloading when underlying configuration files change.</param>
+        /// <exception cref="UnauthorizedAccessException">Thrown when invalid tokens are provided</exception>
+        /// <remarks>
+        /// Provides a consolidated interface for token management while maintaining identical security 
+        /// and serialization behavior as the granular token overload.
+        /// </remarks>
+        public void RegisterConfig(Type configType, ITokenSet tokenSet, JsonSerializerOptions? jsonOptions = null, bool reloadOnChange = false);
+
+
+        /// <summary>
+        /// Registers multiple configuration types with shared token policies and type-specific JSON serialization settings.
+        /// </summary>
+        /// <param name="configTypes">The types representing configurations.</param>
+        /// <param name="ownerToken">Optional token for owner operations. Defaults to a new <see cref="Token"/> if not specified.</param>
+        /// <param name="readToken">Optional token for read operations. Defaults to <see cref="Token.Public"/> if not specified.</param>
+        /// <param name="writeToken">Optional token for write operations. Defaults to <see cref="Token.Blocked"/> if not specified.</param>
+        /// <param name="jsonOptions">Specifies custom JSON serialization settings for these configuration types, allowing per-type control over serialization behavior. Applied to all types in the collection.</param>
+        /// <param name="reloadOnChange">If true, automatically reloads configurations when sources change.</param>
+        /// <exception cref="UnauthorizedAccessException"/>
+        public void RegisterConfigs(IEnumerable<Type> configTypes, Token? ownerToken = null, Token? readToken = null, Token? writeToken = null, JsonSerializerOptions? jsonOptions = null, bool reloadOnChange = false);
+
+        /// <summary>
+        /// Registers multiple configuration types using a consolidated token set for access control, with optional JSON serialization settings.
+        /// </summary>
+        /// <param name="configTypes">The configuration types to register.</param>
+        /// <param name="tokenSet">Consolidated token container for owner/read/write permissions.</param>
+        /// <param name="jsonOptions">Custom JSON serialization settings applied to all specified configuration types.</param>
+        /// <param name="reloadOnChange">Enables automatic reload when underlying configuration files change.</param>
+        /// <exception cref="UnauthorizedAccessException">Thrown if current context lacks permission to register configurations.</exception>
+        public void RegisterConfigs(IEnumerable<Type> configTypes, ITokenSet tokenSet, JsonSerializerOptions? jsonOptions = null, bool reloadOnChange = false);
+
+
+        /// <summary>
+        /// Unregisters a single configuration type from the service, removing all associated settings and change listeners.
+        /// </summary>
+        /// <param name="configType">The <see cref="Type"/> of the configuration to unregister.</param>
+        /// <param name="ownerToken">Optional token for owner operations. Defaults to a new <see cref="Token"/> if not specified.</param>
+        /// <exception cref="UnauthorizedAccessException">Thrown if the provided token does not have write access to the configuration.</exception>
+        /// <remarks>
+        /// This method is thread-safe. If the configuration type is not registered, the operation is a no-op.
+        /// Any registered reload callbacks for the configuration will be disposed.
+        /// </remarks>
+        public void UnregisterConfig(Type configType, Token? ownerToken = null);
+
+        /// <summary>
+        /// Unregisters a single configuration type from the service, removing all associated settings and change listeners.
+        /// </summary>
+        /// <param name="configType">The <see cref="Type"/> of the configuration to unregister.</param>
+        /// <param name="tokenSet">Consolidated token container for owner/read/write permissions.</param>
+        /// <exception cref="UnauthorizedAccessException">Thrown if the provided token does not have write access to the configuration.</exception>
+        /// <remarks>
+        /// This method is thread-safe. If the configuration type is not registered, the operation is a no-op.
+        /// Any registered reload callbacks for the configuration will be disposed.
+        /// </remarks>
+        public void UnregisterConfig(Type configType, ITokenSet tokenSet);
+
+
+        /// <summary>
+        /// Unregisters multiple configuration types from the service, removing all associated settings and change listeners for each.
+        /// </summary>
+        /// <param name="configTypes">A collection of <see cref="Type"/> objects representing the configurations to unregister.</param>
+        /// <param name="ownerToken">Optional token for owner operations. Defaults to a new <see cref="Token"/> if not specified.</param>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="configTypes"/> is null.</exception>
+        /// <exception cref="UnauthorizedAccessException">Thrown if the provided token does not have write access to any configuration in the collection.</exception>
+        /// <remarks>
+        /// This method is thread-safe. If a configuration type in the collection is not registered, it is skipped.
+        /// Any registered reload callbacks for each configuration will be disposed.
+        /// </remarks>
+        public void UnregisterConfigs(IEnumerable<Type> configTypes, Token? ownerToken = null);
+
+        /// <summary>
+        /// Unregisters multiple configuration types from the service, removing all associated settings and change listeners for each.
+        /// </summary>
+        /// <param name="configTypes">A collection of <see cref="Type"/> objects representing the configurations to unregister.</param>
+        /// <param name="tokenSet">Consolidated token container for owner/read/write permissions.</param>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="configTypes"/> is null.</exception>
+        /// <exception cref="UnauthorizedAccessException">Thrown if the provided token does not have write access to any configuration in the collection.</exception>
+        /// <remarks>
+        /// This method is thread-safe. If a configuration type in the collection is not registered, it is skipped.
+        /// Any registered reload callbacks for each configuration will be disposed.
+        /// </remarks>
+        public void UnregisterConfigs(IEnumerable<Type> configTypes, ITokenSet tokenSet);
+
+
+        /// <summary>
+        /// Gets the raw contents of the default configuration file for the specified configuration type.
+        /// </summary>
+        /// <param name="configType">The type of the configuration section.</param>
+        /// <param name="ownerToken">Optional token for owner operations. Defaults to a new <see cref="Token"/> if not specified.</param>
+        /// <returns>The contents of the default configuration file as a string.</returns>
+        public string GetDefaultConfigFileContents(Type configType, Token? ownerToken = null);
+
+        /// <summary>
+        /// Gets the raw contents of the default configuration file for the specified configuration type.
+        /// </summary>
+        /// <param name="configType">The type of the configuration section.</param>
+        /// <param name="tokenSet">Consolidated token container for owner/read/write permissions.</param>
+        /// <returns>The contents of the default configuration file as a string.</returns>
+        public string GetDefaultConfigFileContents(Type configType, ITokenSet tokenSet);
+
+
+        /// <summary>
+        /// Asynchronously saves the provided contents to the default configuration file for the specified configuration type.
+        /// </summary>
+        /// <param name="configType">The type of the configuration section.</param>
+        /// <param name="contents">The raw string contents to write to the default configuration file.</param>
+        /// <param name="ownerToken">Optional token for owner operations. Defaults to a new <see cref="Token"/> if not specified.</param>
+        /// <returns>A task representing the asynchronous save operation.</returns>
+        public Task SaveDefaultConfigFileContentsAsync(Type configType, string contents, Token? ownerToken = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Asynchronously saves the provided contents to the default configuration file for the specified configuration type.
+        /// </summary>
+        /// <param name="configType">The type of the configuration section.</param>
+        /// <param name="contents">The raw string contents to write to the default configuration file.</param>
+        /// <param name="tokenSet">Consolidated token container for owner/read/write permissions.</param>
+        /// <returns>A task representing the asynchronous save operation.</returns>
+        public Task SaveDefaultConfigFileContentsAsync(Type configType, string contents, ITokenSet tokenSet, CancellationToken cancellationToken = default);
+
+
+        /// <summary>
+        /// Overwrites the default configuration file for the specified type with the provided JSON contents asynchronously.
+        /// This method initiates the write operation and returns immediately; errors are reported via the <see cref="SyncSaveOpErrors"/> event.
+        /// </summary>
+        /// <param name="configType">The configuration type whose default config file should be overwritten.</param>
+        /// <param name="contents">The raw JSON contents to write to the default config file.</param>
+        /// <param name="ownerToken">Optional token for owner operations. Defaults to a new <see cref="Token"/> if not specified.</param>
+        /// <param name="writeToken">Optional token for write operations. Defaults to <see cref="Token.Blocked"/> if not specified.</param>
+        /// Optional access token for write authorization. If not specified, defaults to <see cref="Token.Public"/>.
+        /// </param>
+        /// <remarks>
+        /// - This is a fire-and-forget operation; exceptions are not thrown synchronously.
+        /// - Errors that occur during the write are surfaced via the <see cref="SyncSaveOpErrors"/> event handler.
+        /// - Use <see cref="SaveDefaultConfigFileContentsAsync"/> for awaitable, exception-aware saving.
+        /// </remarks>
+        public void SaveDefaultConfigFileContents(Type configType, string contents, Token? ownerToken = null);
+
+        /// <summary>
+        /// Overwrites the default configuration file for the specified type with the provided JSON contents asynchronously.
+        /// This method initiates the write operation and returns immediately; errors are reported via the <see cref="SyncSaveOpErrors"/> event.
+        /// </summary>
+        /// <param name="configType">The configuration type whose default config file should be overwritten.</param>
+        /// <param name="contents">The raw JSON contents to write to the default config file.</param>
+        /// <param name="tokenSet">Consolidated token container for owner/read/write permissions.</param>
+        /// Optional access token for write authorization. If not specified, defaults to <see cref="Token.Public"/>.
+        /// </param>
+        /// <remarks>
+        /// - This is a fire-and-forget operation; exceptions are not thrown synchronously.
+        /// - Errors that occur during the write are surfaced via the <see cref="SyncSaveOpErrors"/> event handler.
+        /// - Use <see cref="SaveDefaultConfigFileContentsAsync"/> for awaitable, exception-aware saving.
+        /// </remarks>
+        public void SaveDefaultConfigFileContents(Type configType, string contents, ITokenSet tokenSet);
+
+
+        /// <summary>
+        /// Retrieves a fully populated configuration instance of the specified type.
+        /// This method merges default and user settings according to PlugHub config rules,
+        /// returning an object that reflects the effective configuration state.
+        /// </summary>
+        /// <param name="configType">The Type of configuration class to retrieve</param>
+        /// <param name="ownerToken">Optional token for owner operations. Defaults to a new <see cref="Token"/> if not specified.</param>
+        /// <param name="readToken">Optional token for read operations. Defaults to <see cref="Token.Public"/> if not specified.</param>
+        /// <returns>A populated instance of the requested configuration type</returns>
+        /// <exception cref="KeyNotFoundException">Thrown if configType is not registered</exception>
+        /// <exception cref="InvalidOperationException">Thrown if instance creation fails</exception>
+        public object GetConfigInstance(Type configType, Token? ownerToken = null, Token? readToken = null);
+
+        /// <summary>
+        /// Retrieves a fully populated configuration instance of the specified type.
+        /// This method merges default and user settings according to PlugHub config rules,
+        /// returning an object that reflects the effective configuration state.
+        /// </summary>
+        /// <param name="configType">The Type of configuration class to retrieve</param>
+        /// <param name="tokenSet">Consolidated token container for owner/read/write permissions.</param>
+        /// <returns>A populated instance of the requested configuration type</returns>
+        /// <exception cref="KeyNotFoundException">Thrown if configType is not registered</exception>
+        /// <exception cref="InvalidOperationException">Thrown if instance creation fails</exception>
+        public object GetConfigInstance(Type configType, ITokenSet tokenSet);
+
+
+        /// <summary>
+        /// Persists property values from a configuration instance to storage.
+        /// Applies each property using the config service's merge logic, ensuring user values
+        /// are only stored when they differ from default values (minimal user config footprint).
+        /// </summary>
+        /// <param name="configType">The Type of configuration being updated</param>
+        /// <param name="updatedConfig">Instance containing new property values</param>
+        /// <param name="ownerToken">Optional token for owner operations. Defaults to a new <see cref="Token"/> if not specified.</param>
+        /// <param name="writeToken">Optional token for write operations. Defaults to <see cref="Token.Blocked"/> if not specified.</param>
+        /// <exception cref="ArgumentNullException">Thrown if updatedConfig is null</exception>
+        public Task SaveConfigInstanceAsync(Type configType, object updatedConfig, Token? ownerToken = null, Token? writeToken = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Persists property values from a configuration instance to storage.
+        /// Applies each property using the config service's merge logic, ensuring user values
+        /// are only stored when they differ from default values (minimal user config footprint).
+        /// </summary>
+        /// <param name="configType">The Type of configuration being updated</param>
+        /// <param name="updatedConfig">Instance containing new property values</param>
+        /// <param name="tokenSet">Consolidated token container for owner/read/write permissions.</param>
+        /// <exception cref="ArgumentNullException">Thrown if updatedConfig is null</exception>
+        public Task SaveConfigInstanceAsync(Type configType, object updatedConfig, ITokenSet tokenSet, CancellationToken cancellationToken = default);
+
+
+        /// <summary>
+        /// Saves the provided configuration object instance to the user settings file for the specified type asynchronously.
+        /// This method initiates the save operation and returns immediately; errors are reported via the <see cref="SyncSaveOpErrors"/> event.
+        /// </summary>
+        /// <param name="configType">The configuration type whose settings should be updated.</param>
+        /// <param name="updatedConfig">The updated configuration object to persist.</param>
+        /// <param name="ownerToken">Optional token for owner operations. Defaults to a new <see cref="Token"/> if not specified.</param>
+        /// <param name="writeToken">Optional token for write operations. Defaults to <see cref="Token.Blocked"/> if not specified.</param>
+        /// Optional access token for write authorization. If not specified, defaults to <see cref="Token.Public"/>.
+        /// </param>
+        /// <remarks>
+        /// - This is a fire-and-forget operation; exceptions are not thrown synchronously.
+        /// - Errors that occur during the save are surfaced via the <see cref="SyncSaveOpErrors"/> event handler.
+        /// - Use <see cref="SaveConfigInstanceAsync"/> for awaitable, exception-aware saving.
+        /// </remarks>
+        public void SaveConfigInstance(Type configType, object updatedConfig, Token? ownerToken = null, Token? writeToken = null);
+
+        /// <summary>
+        /// Saves the provided configuration object instance to the user settings file for the specified type asynchronously.
+        /// This method initiates the save operation and returns immediately; errors are reported via the <see cref="SyncSaveOpErrors"/> event.
+        /// </summary>
+        /// <param name="configType">The configuration type whose settings should be updated.</param>
+        /// <param name="updatedConfig">The updated configuration object to persist.</param>
+        /// <param name="tokenSet">Consolidated token container for owner/read/write permissions.</param>
+        /// Optional access token for write authorization. If not specified, defaults to <see cref="Token.Public"/>.
+        /// </param>
+        /// <remarks>
+        /// - This is a fire-and-forget operation; exceptions are not thrown synchronously.
+        /// - Errors that occur during the save are surfaced via the <see cref="SyncSaveOpErrors"/> event handler.
+        /// - Use <see cref="SaveConfigInstanceAsync"/> for awaitable, exception-aware saving.
+        /// </remarks>
+        public void SaveConfigInstance(Type configType, object updatedConfig, ITokenSet tokenSet);
+
+
+        /// <summary>
+        /// Gets a read-only <see cref="IConfiguration"/> representing the current environment variables and command-line arguments.
+        /// </summary>
+        /// <returns>An <see cref="IConfiguration"/> instance containing environment and command-line settings. This object is read-only.</returns>
+        public IConfiguration GetEnvConfig();
+
+
+        /// <summary>
+        /// Returns the *baseline* value that was loaded from
+        /// <c>&lt;{configType.Name}&gt;.DefaultSettings.json</c> for the property named
+        /// <paramref name="key"/> – ignoring any user-override that might currently exist.
+        /// </summary>
+        /// <typeparam name="T">Desired return type.  If the stored object implements <see cref="IConvertible"/> it is converted to <typeparamref name="T"/>; otherwise the method attempts a direct cast.</typeparam>
+        /// <param name="configType">CLR type that models the configuration section whose default you want to inspect. Must have been registered with the configuration service.</param>
+        /// <param name="key">Public property name declared on <paramref name="configType"/>.</param>
+        /// <param name="ownerToken">Optional token for owner operations. Defaults to a new <see cref="Token"/> if not specified.</param>
+        /// <param name="readToken">Optional token for read operations. Defaults to <see cref="Token.Public"/> if not specified.</param>
+        /// <returns> The default value converted to <typeparamref name="T"/>; <see langword="default"/> when the conversion cannot be performed.</returns>
+        /// <exception cref="ConfigTypeNotFoundException">Thrown when <paramref name="configType"/> has not been registered.</exception>
+        /// <exception cref="KeyNotFoundException">Thrown when the supplied <paramref name="key"/> does not exist in the defaults file.</exception>
+        /// <remarks>
+        /// For properties marked *secure*, the return value is a <c>SecureValue</c> instance
+        /// containing the encrypted Base-64 payload.
+        /// The method is crypto-agnostic; no decryption occurs inside <c>ConfigService</c>.
+        /// </remarks>
+        T? GetDefault<T>(Type configType, string key, Token? ownerToken = null, Token? readToken = null);
+
+        /// <summary>
+        /// Returns the *baseline* value that was loaded from
+        /// <c>&lt;{configType.Name}&gt;.DefaultSettings.json</c> for the property named
+        /// <paramref name="key"/> – ignoring any user-override that might currently exist.
+        /// </summary>
+        /// <typeparam name="T">Desired return type.  If the stored object implements <see cref="IConvertible"/> it is converted to <typeparamref name="T"/>; otherwise the method attempts a direct cast.</typeparam>
+        /// <param name="configType">CLR type that models the configuration section whose default you want to inspect. Must have been registered with the configuration service.</param>
+        /// <param name="key">Public property name declared on <paramref name="configType"/>.</param>
+        /// <param name="tokenSet">Consolidated token container for owner/read/write permissions.</param>
+        /// <returns> The default value converted to <typeparamref name="T"/>; <see langword="default"/> when the conversion cannot be performed.</returns>
+        /// <exception cref="ConfigTypeNotFoundException">Thrown when <paramref name="configType"/> has not been registered.</exception>
+        /// <exception cref="KeyNotFoundException">Thrown when the supplied <paramref name="key"/> does not exist in the defaults file.</exception>
+        /// <remarks>
+        /// For properties marked *secure*, the return value is a <c>SecureValue</c> instance
+        /// containing the encrypted Base-64 payload.
+        /// The method is crypto-agnostic; no decryption occurs inside <c>ConfigService</c>.
+        /// </remarks>
+        T? GetDefault<T>(Type configType, string key, ITokenSet tokenSet);
+
+
+        /// <summary>
+        /// Returns the *effective* value for the property named <paramref name="key"/>,
+        /// i.e.&nbsp;<c>UserValue ?? DefaultValue</c>, using the merge order defined by PlugHub.
+        /// </summary>
+        /// <typeparam name="T">Desired return type. If the stored object implements <see cref="IConvertible"/>, it is converted to <typeparamref name="T"/>; otherwise the method attempts a direct cast.</typeparam>
+        /// <param name="configType">CLR type that models the configuration section you want to query.Must have been registered with the configuration service.</param>
+        /// <param name="key">Public property name declared on <paramref name="configType"/>.</param>
+        /// <param name="ownerToken">Optional token for owner operations. Defaults to a new <see cref="Token"/> if not specified.</param>
+        /// <param name="readToken">Optional token for read operations. Defaults to <see cref="Token.Public"/> if not specified.</param>
+        /// <returns>The effective value converted to <typeparamref name="T"/>; <see langword="default"/> when the conversion cannot be performed.</returns>
+        /// <exception cref="ConfigTypeNotFoundException">Thrown when <paramref name="configType"/> has not been registered.</exception>
+        /// <exception cref="KeyNotFoundException">Thrown when the supplied <paramref name="key"/> does not exist in the configuration.</exception>
+        /// <exception cref="UnauthorizedAccessException">Thrown when the caller, as identified by <paramref name="readToken"/>, does not have read access to the requested setting.</exception>
+        /// <remarks>
+        /// For properties marked *secure*, the returned value is a <c>SecureValue</c> object
+        /// containing the encrypted Base-64 payload unless the caller explicitly requests a
+        /// decrypted type via a secure accessor.
+        /// </remarks>
+        public T? GetSetting<T>(Type configType, string key, Token? ownerToken = null, Token? readToken = null);
+
+        /// <summary>
+        /// Returns the *effective* value for the property named <paramref name="key"/>,
+        /// i.e.&nbsp;<c>UserValue ?? DefaultValue</c>, using the merge order defined by PlugHub.
+        /// </summary>
+        /// <typeparam name="T">Desired return type. If the stored object implements <see cref="IConvertible"/>, it is converted to <typeparamref name="T"/>; otherwise the method attempts a direct cast.</typeparam>
+        /// <param name="configType">CLR type that models the configuration section you want to query.Must have been registered with the configuration service.</param>
+        /// <param name="key">Public property name declared on <paramref name="configType"/>.</param>
+        /// <param name="tokenSet">Consolidated token container for owner/read/write permissions.</param>
+        /// <returns>The effective value converted to <typeparamref name="T"/>; <see langword="default"/> when the conversion cannot be performed.</returns>
+        /// <exception cref="ConfigTypeNotFoundException">Thrown when <paramref name="configType"/> has not been registered.</exception>
+        /// <exception cref="KeyNotFoundException">Thrown when the supplied <paramref name="key"/> does not exist in the configuration.</exception>
+        /// <exception cref="UnauthorizedAccessException">Thrown when the caller, as identified by <paramref name="readToken"/>, does not have read access to the requested setting.</exception>
+        /// <remarks>
+        /// For properties marked *secure*, the returned value is a <c>SecureValue</c> object
+        /// containing the encrypted Base-64 payload unless the caller explicitly requests a
+        /// decrypted type via a secure accessor.
+        /// </remarks>
+        public T? GetSetting<T>(Type configType, string key, ITokenSet tokenSet);
+
+
+        /// <summary>
+        /// Sets a type-specific setting by type and key.
+        /// </summary>
+        /// <typeparam name="T">The type of the setting value.</typeparam>
+        /// <param name="configType">The configuration type.</param>
+        /// <param name="key">The setting key.</param>
+        /// <param name="value">The setting value.</param>
+        /// <param name="ownerToken">Optional token for owner operations. Defaults to a new <see cref="Token"/> if not specified.</param>
+        /// <param name="writeToken">Optional token for write operations. Defaults to <see cref="Token.Blocked"/> if not specified.</param>
+        public void SetSetting<T>(Type configType, string key, T? value, Token? ownerToken = null, Token? writeToken = null);
+
+        /// <summary>
+        /// Sets a type-specific setting by type and key.
+        /// </summary>
+        /// <typeparam name="T">The type of the setting value.</typeparam>
+        /// <param name="configType">The configuration type.</param>
+        /// <param name="key">The setting key.</param>
+        /// <param name="value">The setting value.</param>
+        /// <param name="tokenSet">Consolidated token container for owner/read/write permissions.</param>
+        public void SetSetting<T>(Type configType, string key, T? value, ITokenSet tokenSet);
+
+
+        /// <summary>
+        /// Saves the current user and default settings for the specified configuration type to disk asynchronously.
+        /// This method initiates the save operation and returns immediately; errors are reported via the <see cref="SyncSaveOpErrors"/> event.
+        /// </summary>
+        /// <param name="configType">The configuration type whose settings should be saved.</param>
+        /// <param name="ownerToken">Optional token for owner operations. Defaults to a new <see cref="Token"/> if not specified.</param>
+        /// <param name="writeToken">Optional token for write operations. Defaults to <see cref="Token.Blocked"/> if not specified.</param>
+        /// Optional access token for write authorization. If not specified, defaults to <see cref="Token.Public"/>.
+        /// </param>
+        /// <remarks>
+        /// - This is a fire-and-forget operation; exceptions are not thrown synchronously.
+        /// - Errors that occur during the save are surfaced via the <see cref="SyncSaveOpErrors"/> event handler.
+        /// - Use <see cref="SaveSettingsAsync"/> for awaitable, exception-aware saving.
+        /// </remarks>
+        public void SaveSettings(Type configType, Token? ownerToken = null, Token? writeToken = null);
+
+        /// <summary>
+        /// Saves the current user and default settings for the specified configuration type to disk asynchronously.
+        /// This method initiates the save operation and returns immediately; errors are reported via the <see cref="SyncSaveOpErrors"/> event.
+        /// </summary>
+        /// <param name="configType">The configuration type whose settings should be saved.</param>
+        /// <param name="tokenSet">Consolidated token container for owner/read/write permissions.</param>
+        /// Optional access token for write authorization. If not specified, defaults to <see cref="Token.Public"/>.
+        /// </param>
+        /// <remarks>
+        /// - This is a fire-and-forget operation; exceptions are not thrown synchronously.
+        /// - Errors that occur during the save are surfaced via the <see cref="SyncSaveOpErrors"/> event handler.
+        /// - Use <see cref="SaveSettingsAsync"/> for awaitable, exception-aware saving.
+        /// </remarks>
+        public void SaveSettings(Type configType, ITokenSet tokenSet);
+
+
+        /// <summary>
+        /// Saves settings for a specific type.
+        /// </summary>
+        /// <param name="configType">The configuration type.</param>
+        /// <param name="ownerToken">Optional token for owner operations. Defaults to a new <see cref="Token"/> if not specified.</param>
+        /// <param name="writeToken">Optional token for write operations. Defaults to <see cref="Token.Blocked"/> if not specified.</param>
+        public Task SaveSettingsAsync(Type configType, Token? ownerToken = null, Token? writeToken = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Saves settings for a specific type.
+        /// </summary>
+        /// <param name="configType">The configuration type.</param>
+        /// <param name="tokenSet">Consolidated token container for owner/read/write permissions.</param>
+        public Task SaveSettingsAsync(Type configType, ITokenSet tokenSet, CancellationToken cancellationToken = default);
+    }
+}

--- a/PlugHub.Shared/Utility/Atomic.cs
+++ b/PlugHub.Shared/Utility/Atomic.cs
@@ -1,0 +1,100 @@
+﻿using System.Text;
+
+namespace PlugHub.Shared.Utility
+{
+    /// <summary>
+    /// Cross-platform helper for atomic, multi-process-safe file writes.
+    /// </summary>
+    public static class Atomic
+    {
+        /// <summary>Ensures the directory containing <paramref name="path"/> exists.</summary>
+        private static void EnsureDirectoryExists(string path)
+        {
+            string? dir = Path.GetDirectoryName(path);
+            if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+                Directory.CreateDirectory(dir);
+        }
+
+
+
+        /// <summary>
+        /// UTF-8 helper that converts <paramref name="contents"/> to bytes and delegates to the primary writer.
+        /// </summary>
+        public static Task WriteAsync(string destinationPath, string contents, int maxRetries = 3, int baseDelayMs = 200, CancellationToken cancellationToken = default)
+            => WriteAsync(destinationPath, Encoding.UTF8.GetBytes(contents), maxRetries, baseDelayMs, cancellationToken);
+
+        /// <summary>
+        /// Atomically writes <paramref name="bytes"/> to <paramref name="destinationPath"/> asynchronously.
+        /// Retries up to <paramref name="maxRetries"/> times on transient <see cref="IOException"/>s.
+        /// </summary>
+        public static async Task WriteAsync(string destinationPath, ReadOnlyMemory<byte> bytes, int maxRetries = 3, int baseDelayMs = 200, CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(destinationPath);
+            ArgumentNullException.ThrowIfNull(bytes);
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            EnsureDirectoryExists(destinationPath);
+
+            for (int attempt = 1; attempt <= maxRetries; attempt++)
+            {
+                string tempPath = Path.GetTempFileName();
+
+                try
+                {
+                    await using (FileStream fs =
+                        new(
+                        tempPath,
+                        FileMode.Create,
+                        FileAccess.Write,
+                        FileShare.None | FileShare.Delete,
+                        bufferSize: 8192,
+                        options: FileOptions.Asynchronous | FileOptions.WriteThrough)) await fs.WriteAsync(bytes, cancellationToken);
+
+                    if (File.Exists(destinationPath))
+                        File.Replace(tempPath, destinationPath, null, ignoreMetadataErrors: true);
+                    else
+                        File.Move(tempPath, destinationPath);
+
+                    return;
+                }
+                catch (IOException) when (attempt < maxRetries)
+                {
+                    await Task.Delay(baseDelayMs * (1 << (attempt - 1)), cancellationToken);
+                }
+                finally
+                {
+                    try { if (File.Exists(tempPath)) File.Delete(tempPath); } catch { /* ignored */ }
+                }
+
+                cancellationToken.ThrowIfCancellationRequested();
+            }
+
+            throw new IOException($"Unable to write '{destinationPath}' after {maxRetries} attempts.");
+        }
+
+
+
+        /// <summary>
+        /// Atomically writes UTF-8 text <paramref name="contents"/> to <paramref name="destinationPath"/>.
+        /// </summary>
+        public static void Write(string destinationPath, string contents) =>
+            Write(destinationPath, Encoding.UTF8.GetBytes(contents));
+
+        /// <summary>
+        /// Atomically writes binary <paramref name="data"/> to <paramref name="destinationPath"/>.
+        /// </summary>
+        public static void Write(string destinationPath, ReadOnlySpan<byte> data)
+        {
+            ArgumentNullException.ThrowIfNull(destinationPath);
+
+            string dir = Path.GetDirectoryName(destinationPath)!;
+            Directory.CreateDirectory(dir);
+
+            string tempPath = Path.Combine(dir, Guid.NewGuid().ToString("N") + ".tmp");
+            File.WriteAllBytes(tempPath, data.ToArray());
+
+            File.Move(tempPath, destinationPath, overwrite: true);
+        }
+    }
+}

--- a/PlugHub.UnitTests/Accessors/ConfigAccessorTests.cs
+++ b/PlugHub.UnitTests/Accessors/ConfigAccessorTests.cs
@@ -1,0 +1,455 @@
+﻿using Microsoft.Extensions.Logging.Abstractions;
+using PlugHub.Accessors;
+using PlugHub.Services;
+using PlugHub.Shared.Interfaces.Accessors;
+using PlugHub.Shared.Interfaces.Services;
+using PlugHub.Shared.Models;
+
+namespace PlugHub.UnitTests.Accessors
+{
+    [TestClass]
+    public class ConfigAccessorTests
+    {
+        private readonly MSTestHelpers msTestHelpers = new();
+        private TokenService? tokenService;
+        private ConfigService? configService;
+
+
+        internal class UnitTestAConfig
+        {
+            public int FieldA { get; set; } = 50;
+            public bool FieldB { get; set; } = false;
+            public float FieldC { get; } = 2.71828f;
+        }
+        internal class UnitTestBConfig
+        {
+            public string FieldA { get; set; } = "plughub";
+            public int FieldB { get; set; } = 100;
+            public float FieldC { get; } = 3.14f;
+        }
+
+
+        [TestInitialize]
+        public void Setup()
+        {
+            this.tokenService = new TokenService(new NullLogger<ITokenService>());
+
+            this.configService = new ConfigService(
+                new NullLogger<IConfigService>(),
+                this.tokenService,
+                this.msTestHelpers.TempDirectory,
+                this.msTestHelpers.TempDirectory);
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            (this.configService as IDisposable)?.Dispose();
+            this.msTestHelpers.Dispose();
+        }
+
+
+        #region ConfigAccessorTests: Registration
+
+        [TestMethod]
+        [TestCategory("Registration")]
+        public void For_UnregisteredType_Throws()
+        {
+            // Arrange & Act
+            ConfigAccessor accessor = new(
+                this.configService!,
+                this.tokenService!,
+                [typeof(UnitTestAConfig)],
+                this.tokenService!.CreateToken(),
+                Token.Public,
+                Token.Public);
+
+            // Assert
+            Assert.ThrowsException<ConfigTypeNotFoundException>(() => accessor.For<UnitTestBConfig>());
+        }
+
+        [TestMethod]
+        [TestCategory("Registration")]
+        public void For_RegisteredType_Succeeds()
+        {
+            // Arrange
+            this.configService!.RegisterConfig(typeof(UnitTestAConfig));
+            ConfigAccessor accessor = new(
+                this.configService,
+                this.tokenService!,
+                [typeof(UnitTestAConfig)],
+                this.tokenService!.CreateToken(),
+                Token.Public,
+                Token.Public);
+
+            // Act
+            IConfigAccessorFor<UnitTestAConfig> stronglyTyped = accessor.For<UnitTestAConfig>();
+
+            // Assert
+            Assert.IsInstanceOfType<IConfigAccessorFor<UnitTestAConfig>>(stronglyTyped);
+        }
+
+        #endregion
+
+        #region ConfigAccessorTests: Accessors
+
+        [TestMethod]
+        [TestCategory("Accessors")]
+        public void Get_ReturnsDefaultValue()
+        {
+            //Arrange
+            this.configService!.RegisterConfig(typeof(UnitTestAConfig));
+            ConfigAccessor accessor = new(
+                this.configService,
+                this.tokenService!,
+                [typeof(UnitTestAConfig)],
+                this.tokenService!.CreateToken(),
+                Token.Public,
+                Token.Public);
+
+            IConfigAccessorFor<UnitTestAConfig> a = accessor.For<UnitTestAConfig>();
+
+            // Act
+            int value = a.Get<int>(nameof(UnitTestAConfig.FieldA));
+
+            // Assert
+            Assert.AreEqual(50, value);
+        }
+
+        [TestMethod]
+        [TestCategory("Accessors")]
+        public void Get_ReturnsMergedInstanceWithUserOverrides()
+        {
+            // Arrange
+            Token owner = this.tokenService!.CreateToken();
+            Token read = this.tokenService!.CreateToken();
+            Token write = this.tokenService.CreateToken();
+
+            this.configService!.RegisterConfig(typeof(UnitTestAConfig), owner, read, write);
+            this.configService.SetSetting(typeof(UnitTestAConfig), nameof(UnitTestAConfig.FieldA), 99, writeToken: write);
+
+            ConfigAccessor accessor = new(this.configService, this.tokenService, [typeof(UnitTestAConfig)], owner, read, write);
+            IConfigAccessorFor<UnitTestAConfig> aConfig = accessor.For<UnitTestAConfig>();
+
+            // Act
+            UnitTestAConfig instance = aConfig.Get();
+
+            // Assert
+            Assert.AreEqual(99, instance.FieldA);
+            Assert.IsFalse(instance.FieldB);
+            Assert.AreEqual(2.71828f, instance.FieldC);
+        }
+
+        [TestMethod]
+        [TestCategory("Validation")]
+        public void Get_WithNullKey_Throws()
+        {
+            // Arrange
+            Token owner = this.tokenService!.CreateToken();
+            Token read = this.tokenService!.CreateToken();
+            Token write = this.tokenService!.CreateToken();
+            this.configService!.RegisterConfig(typeof(UnitTestAConfig), readToken: read, writeToken: write);
+
+            // Act
+            ConfigAccessor accessor = new(this.configService, this.tokenService, [typeof(UnitTestAConfig)], owner, read, write);
+            IConfigAccessorFor<UnitTestAConfig> config = accessor.For<UnitTestAConfig>();
+
+            // Assert
+            Assert.ThrowsException<ArgumentNullException>(() => config.Get<int>(null!));
+        }
+
+        #endregion
+
+        #region ConfigAccessorTests: Mutators
+
+        [TestMethod]
+        [TestCategory("Mutators")]
+        public void Set_ThenGet_ReturnsUpdatedValue()
+        {
+            // Arrange
+            Token read = this.tokenService!.CreateToken();
+            Token write = this.tokenService.CreateToken();
+
+            // Act
+            this.configService!.RegisterConfig(typeof(UnitTestAConfig), readToken: read, writeToken: write);
+
+            ConfigAccessor accessor = new(
+                this.configService,
+                this.tokenService,
+                [typeof(UnitTestAConfig)],
+                this.tokenService.CreateToken(),
+                read,
+                write);
+
+            IConfigAccessorFor<UnitTestAConfig> a = accessor.For<UnitTestAConfig>();
+
+            a.Set(nameof(UnitTestAConfig.FieldA), 123);
+
+            int value = a.Get<int>(nameof(UnitTestAConfig.FieldA));
+
+            // Assert
+            Assert.AreEqual(123, value);
+        }
+
+        [TestMethod]
+        [TestCategory("Mutators")]
+        public async Task Save_ModifiedInstance_PersistsChanges()
+        {
+            // Arrange
+            Token owner = this.tokenService!.CreateToken();
+            Token read = this.tokenService!.CreateToken();
+            Token write = this.tokenService.CreateToken();
+            this.configService!.RegisterConfig(typeof(UnitTestAConfig), owner, read, write);
+
+            ConfigAccessor accessor = new(this.configService, this.tokenService, [typeof(UnitTestAConfig)], owner, read, write);
+            IConfigAccessorFor<UnitTestAConfig> aConfig = accessor.For<UnitTestAConfig>();
+
+            UnitTestAConfig editable = aConfig.Get();
+            editable.FieldA = 123;
+            editable.FieldB = true;
+
+            // Act
+            await aConfig.SaveAsync(editable);
+
+            // Assert
+            int storedA = this.configService.GetSetting<int>(typeof(UnitTestAConfig), nameof(UnitTestAConfig.FieldA), readToken: read);
+            bool storedB = this.configService.GetSetting<bool>(typeof(UnitTestAConfig), nameof(UnitTestAConfig.FieldB), readToken: read);
+
+            Assert.AreEqual(123, storedA);
+            Assert.IsTrue(storedB);
+
+            UnitTestAConfig reloaded = aConfig.Get();
+            Assert.AreEqual(123, reloaded.FieldA);
+            Assert.IsTrue(reloaded.FieldB);
+        }
+
+        [TestMethod]
+        [TestCategory("Mutators")]
+        public async Task SaveAsync_WithInvalidToken_Throws()
+        {
+            // Arrange
+            Token owner = this.tokenService!.CreateToken();
+            Token read = this.tokenService!.CreateToken();
+            Token write = this.tokenService.CreateToken();
+            this.configService!.RegisterConfig(typeof(UnitTestAConfig), readToken: read, writeToken: write);
+
+            // Act
+            ConfigAccessor accessor = new(this.configService, this.tokenService, [typeof(UnitTestAConfig)], owner, read, Token.Public);
+            IConfigAccessorFor<UnitTestAConfig> aConfig = accessor.For<UnitTestAConfig>();
+
+            UnitTestAConfig edited = aConfig.Get();
+            edited.FieldA = 42;
+
+            // Aassert
+            await Assert.ThrowsExceptionAsync<UnauthorizedAccessException>(
+                async () => await aConfig.SaveAsync(edited, CancellationToken.None));
+        }
+
+        [TestMethod]
+        [TestCategory("Validation")]
+        public void Set_WithUnknownProperty_Throws()
+        {
+            // Arrange
+            Token owner = this.tokenService!.CreateToken();
+            Token read = this.tokenService!.CreateToken();
+            Token write = this.tokenService!.CreateToken();
+            this.configService!.RegisterConfig(typeof(UnitTestAConfig), readToken: read, writeToken: write);
+
+            // Act
+            ConfigAccessor accessor = new(this.configService, this.tokenService, [typeof(UnitTestAConfig)], owner, read, write);
+            IConfigAccessorFor<UnitTestAConfig> config = accessor.For<UnitTestAConfig>();
+
+            // Assert
+            Assert.ThrowsException<KeyNotFoundException>(() => config.Set("DoesNotExist", 42));
+        }
+
+        #endregion
+
+        #region ConfigAccessorTests: Persistence
+
+        [TestMethod]
+        [TestCategory("Persistence")]
+        public async Task SaveAsync_PersistsToconfigService()
+        {
+            // Arrange
+            Token read = this.tokenService!.CreateToken();
+            Token write = this.tokenService.CreateToken();
+            this.configService!.RegisterConfig(typeof(UnitTestAConfig), readToken: read, writeToken: write);
+
+            // Act
+            ConfigAccessor accessor = new(
+                this.configService,
+                this.tokenService,
+                [typeof(UnitTestAConfig)],
+                this.tokenService.CreateToken(),
+                read,
+                write);
+
+            IConfigAccessorFor<UnitTestAConfig> a = accessor.For<UnitTestAConfig>();
+
+            a.Set(nameof(UnitTestAConfig.FieldA), 777);
+
+            await a.SaveAsync(CancellationToken.None);
+
+            // Assert
+            int stored = this.configService.GetSetting<int>(typeof(UnitTestAConfig), nameof(UnitTestAConfig.FieldA), readToken: read);
+
+            Assert.AreEqual(777, stored);
+        }
+
+        [TestMethod]
+        [TestCategory("Persistence")]
+        public async Task SaveAsync_WithCancelledToken_DoesNotPersistTo_Disk()
+        {
+            // Arrange
+            Token read = this.tokenService!.CreateToken();
+            Token write = this.tokenService.CreateToken();
+            this.configService!.RegisterConfig(typeof(UnitTestAConfig), readToken: read, writeToken: write);
+
+            ConfigAccessor accessor = new(
+                this.configService,
+                this.tokenService,
+                [typeof(UnitTestAConfig)],
+                this.tokenService.CreateToken(),
+                read,
+                write);
+
+            IConfigAccessorFor<UnitTestAConfig> a = accessor.For<UnitTestAConfig>();
+            a.Set(nameof(UnitTestAConfig.FieldA), 9001);
+
+            string filePath = Path.Combine(
+                this.msTestHelpers.TempDirectory,
+                $"{nameof(UnitTestAConfig)}.json");
+
+            // Act & Assert
+            using (CancellationTokenSource cts = new())
+            {
+                cts.Cancel();
+                await Assert.ThrowsExceptionAsync<OperationCanceledException>(
+                    () => a.SaveAsync(cts.Token),
+                    "SaveAsync should propagate a pre-cancelled token.");
+            }
+
+            Assert.IsFalse(File.Exists(filePath),
+                "Cancelled SaveAsync must not create or update the settings file on disk.");
+        }
+
+        [TestMethod]
+        [TestCategory("Persistence")]
+        public async Task SaveSettingsAsync_RoundTripsThroughFreshConfigService()
+        {
+            // Arrange
+            Token read = this.tokenService!.CreateToken();
+            Token write = this.tokenService.CreateToken();
+            this.configService!.RegisterConfig(typeof(UnitTestAConfig), readToken: read, writeToken: write);
+
+            ConfigAccessor accessor = new(
+                this.configService,
+                this.tokenService,
+                [typeof(UnitTestAConfig)],
+                this.tokenService.CreateToken(),
+                read,
+                write);
+
+            IConfigAccessorFor<UnitTestAConfig> a = accessor.For<UnitTestAConfig>();
+            a.Set(nameof(UnitTestAConfig.FieldA), 424242);
+
+            // Act
+            await a.SaveAsync(CancellationToken.None);
+
+            // Assert
+            string filePath = Path.Combine(
+                this.msTestHelpers.TempDirectory,
+                $"{nameof(UnitTestAConfig)}.UserSettings.json");
+
+            Assert.IsTrue(File.Exists(filePath), "Settings file should be written to disk.");
+
+            string json = await File.ReadAllTextAsync(filePath);
+            StringAssert.Contains(json, "424242", "Persisted JSON should include the updated value.");
+
+            TokenService newTokenService = new(new NullLogger<ITokenService>());
+
+            using ConfigService newConfigService = new(
+                new NullLogger<IConfigService>(),
+                newTokenService,
+                this.msTestHelpers.TempDirectory,
+                this.msTestHelpers.TempDirectory);
+
+            Token freshRead = newTokenService.CreateToken();
+            newConfigService.RegisterConfig(typeof(UnitTestAConfig), readToken: freshRead);
+
+            int roundTripped = newConfigService.GetSetting<int>(
+                typeof(UnitTestAConfig),
+                nameof(UnitTestAConfig.FieldA),
+                this.tokenService.CreateToken(),
+                freshRead);
+
+            Assert.AreEqual(424242, roundTripped,
+                "A fresh ConfigService should read back the value that was flushed to disk.");
+        }
+
+
+        #endregion
+
+        #region ConfigAccessorTests: Security
+
+        [TestMethod]
+        [TestCategory("Security")]
+        public void Set_WithInvalidWriteToken_Throws()
+        {
+            // Arrange
+            Token read = this.tokenService!.CreateToken();
+            Token write = this.tokenService.CreateToken();
+            this.configService!.RegisterConfig(typeof(UnitTestAConfig), readToken: read, writeToken: write);
+
+            // Act
+            ConfigAccessor accessor = new(
+                this.configService,
+                this.tokenService,
+                [typeof(UnitTestAConfig)],
+                this.tokenService.CreateToken(),
+                read,
+                Token.Public);
+
+            IConfigAccessorFor<UnitTestAConfig> a = accessor.For<UnitTestAConfig>();
+
+            // Assert
+            Assert.ThrowsException<UnauthorizedAccessException>(
+                () => a.Set(nameof(UnitTestAConfig.FieldA), 999));
+        }
+        #endregion
+
+        #region ConfigAccessorTests: Concurrency
+
+        [TestMethod]
+        [TestCategory("Concurrency")]
+        public async Task Concurrent_Set_Get_Does_Not_Throw_And_Value_Remains_Valid()
+        {
+            // Arrange
+            Token owner = this.tokenService!.CreateToken();
+            Token read = this.tokenService!.CreateToken();
+            Token write = this.tokenService!.CreateToken();
+            this.configService!.RegisterConfig(typeof(UnitTestAConfig), readToken: read, writeToken: write);
+            ConfigAccessor accessor = new(this.configService, this.tokenService, [typeof(UnitTestAConfig)], owner, read, write);
+            IConfigAccessorFor<UnitTestAConfig> config = accessor.For<UnitTestAConfig>();
+
+            // Act
+            const int iterations = 50;
+            IEnumerable<Task> tasks = Enumerable.Range(0, iterations).Select(i =>
+                Task.Run(() =>
+                {
+                    config.Set(nameof(UnitTestAConfig.FieldA), i);
+                    _ = config.Get<int>(nameof(UnitTestAConfig.FieldA));
+                }));
+
+            await Task.WhenAll(tasks);
+
+            // Assert
+            int final = config.Get<int>(nameof(UnitTestAConfig.FieldA));
+
+            Assert.IsTrue(final >= 0 && final < iterations, "Final value should be one of the written values.");
+        }
+
+        #endregion
+    }
+}

--- a/PlugHub.UnitTests/MSTestHelpers.cs
+++ b/PlugHub.UnitTests/MSTestHelpers.cs
@@ -1,0 +1,24 @@
+﻿using PlugHub.Shared.Utility;
+
+namespace PlugHub.UnitTests
+{
+    internal sealed class MSTestHelpers : IDisposable
+    {
+        public Guid Guid { get; set; }
+        public string TempDirectory { get; set; }
+
+        public MSTestHelpers()
+        {
+            this.Guid = Guid.NewGuid();
+            this.TempDirectory = Path.Combine(Path.GetTempPath(), "PlugHubTest", this.Guid.ToString());
+        }
+        public void Dispose()
+        {
+            if (!string.IsNullOrWhiteSpace(this.TempDirectory) && Directory.Exists(this.TempDirectory))
+                Directory.Delete(this.TempDirectory, recursive: true);
+        }
+
+        public void CreateTempFile(string text, string filename)
+            => Atomic.Write(Path.Combine(this.TempDirectory, filename), text);
+    }
+}

--- a/PlugHub.UnitTests/Services/ConfigServiceTests.cs
+++ b/PlugHub.UnitTests/Services/ConfigServiceTests.cs
@@ -1,0 +1,765 @@
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using PlugHub.Services;
+using PlugHub.Shared.Extensions;
+using PlugHub.Shared.Interfaces.Models;
+using PlugHub.Shared.Interfaces.Services;
+using PlugHub.Shared.Models;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace PlugHub.UnitTests.Services
+{
+    [TestClass]
+    public sealed class ConfigServiceTests
+    {
+        private readonly MSTestHelpers msTestHelpers = new();
+        private TokenService? tokenService;
+        private ConfigService? configService;
+        private Token readToken;
+        private Token writeToken;
+
+
+        internal class UnitTestAConfig
+        {
+            public int FieldA { get; set; } = 50;
+            public bool FieldB { get; set; } = false;
+            public float FieldC { get; } = 2.71828f;
+        }
+        internal class UnitTestBConfig
+        {
+            public required string FieldA { get; set; } = "plughub";
+            public int FieldB { get; set; } = 100;
+            public float FieldC { get; } = 3.14f;
+        }
+
+
+        [TestInitialize]
+        public void Setup()
+        {
+            this.tokenService = new TokenService(new NullLogger<TokenService>());
+
+            this.readToken = this.tokenService.CreateToken();
+            this.writeToken = this.tokenService.CreateToken();
+
+            this.configService = new(
+                new NullLogger<IConfigService>(),
+                this.tokenService,
+                this.msTestHelpers.TempDirectory,
+                this.msTestHelpers.TempDirectory);
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            if (this.configService != null)
+                ((IDisposable)this.configService).Dispose();
+
+            this.msTestHelpers!.Dispose();
+        }
+
+
+        #region ConfigServiceTests: Registration
+
+        [TestMethod]
+        [TestCategory("Registration")]
+        public void RegisterConfigs_WithExistingRegistration_InvalidOperationThrows()
+        {
+            // Arrange
+            Token ownerToken = this.tokenService!.CreateToken();
+            Token attackerToken = this.tokenService!.CreateToken();
+
+            this.configService!.RegisterConfigs([typeof(UnitTestAConfig)], writeToken: ownerToken);
+
+            // Act & Assert
+            Assert.ThrowsException<InvalidOperationException>(() =>
+                this.configService.RegisterConfigs([typeof(UnitTestAConfig)], writeToken: attackerToken));
+        }
+
+        [TestMethod]
+        [TestCategory("Registration")]
+        public void RegisterConfigs_ValidTypes_RegistersSuccessfully()
+        {
+            // Arrange
+            List<Type> configTypes = [typeof(UnitTestAConfig), typeof(UnitTestBConfig)];
+
+            string typeAlphaConfigPath =
+                Path.Combine(this.msTestHelpers.TempDirectory, "UnitTestAConfig.DefaultSettings.json");
+            string typeBetaConfigPath =
+                Path.Combine(this.msTestHelpers.TempDirectory, "UnitTestBConfig.UserSettings.json");
+
+            // Act
+            this.msTestHelpers.CreateTempFile("{\r\n  \"FieldA\": 80,\r\n  \"FieldB\": true\r\n}", typeAlphaConfigPath);
+            this.msTestHelpers.CreateTempFile("{\r\n  \"FieldA\": \"Yazza!\",\r\n  \"FieldB\": 60\r\n}", typeBetaConfigPath);
+
+            this.configService!.RegisterConfigs(configTypes);
+
+            // Assert
+            Assert.AreEqual(80, this.configService.GetSetting<int>(typeof(UnitTestAConfig), "FieldA"));
+            Assert.AreEqual("Yazza!", this.configService.GetSetting<string>(typeof(UnitTestBConfig), "FieldA"));
+        }
+
+        [TestMethod]
+        [TestCategory("Registration")]
+        public void RegisterConfigs_InvalidConfig_ThrowsIOException()
+        {
+            // Arrnage
+            List<Type> configTypes = [typeof(UnitTestAConfig)];
+
+            string typeAlphaConfigPath =
+                Path.Combine(this.msTestHelpers.TempDirectory, "UnitTestAConfig.DefaultSettings.json");
+
+            // Act
+            this.msTestHelpers.CreateTempFile("INVALID_JSON", typeAlphaConfigPath);
+
+            // Assert
+            IOException ex = Assert.ThrowsException<IOException>(() =>
+                this.configService!.RegisterConfigs(configTypes));
+
+            Assert.IsInstanceOfType(ex, typeof(IOException));
+        }
+
+        [TestCategory("Registration")]
+        [DataTestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
+        public void RegisterConfig_InvalidJson_ThrowsIOException_ThenGetConfigInstance_ReturnsDefault(bool duringRegistration)
+        {
+            // Arrange
+            string typeConfigPath =
+                Path.Combine(this.msTestHelpers.TempDirectory!, "UnitTestAConfig.DefaultSettings.json");
+
+            Token token = this.tokenService!.CreateToken();
+
+            if (duringRegistration)
+            {
+                // Act
+                this.msTestHelpers.CreateTempFile("INVALIDJSON", typeConfigPath);
+
+                // Assert
+                IOException ex = Assert.ThrowsException<IOException>(() =>
+                    this.configService!.RegisterConfig(typeof(UnitTestAConfig), readToken: token));
+                StringAssert.Contains(ex.Message, "Failed to build");
+            }
+            else
+            {
+                // Act
+                this.msTestHelpers.CreateTempFile("{ \"FieldA\": 100 }", typeConfigPath);
+                this.configService!.RegisterConfig(typeof(UnitTestAConfig), readToken: token);
+                this.msTestHelpers.CreateTempFile("INVALIDJSON", typeConfigPath);
+
+                // Assert
+                UnitTestAConfig config =
+                    (UnitTestAConfig)this.configService.GetConfigInstance(typeof(UnitTestAConfig), readToken: token);
+                Assert.AreEqual(100, config.FieldA); Assert.IsFalse(config.FieldB);
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("Registration")]
+        public void UnregisterConfig_ValidType_RemovesConfigAndSettings()
+        {
+            // Arrange
+            Token token = this.tokenService!.CreateToken();
+
+            this.configService!.RegisterConfig(typeof(UnitTestAConfig), ownerToken: token, readToken: token, writeToken: token);
+
+            // Act
+            object obj = this.configService.GetConfigInstance(typeof(UnitTestAConfig), readToken: token);
+            this.configService.UnregisterConfig(typeof(UnitTestAConfig), token);
+
+            // Assert
+            Assert.IsInstanceOfType<UnitTestAConfig>(obj);
+
+            Assert.ThrowsException<ConfigTypeNotFoundException>(() =>
+                this.configService.GetConfigInstance(typeof(UnitTestAConfig), token));
+        }
+
+        [TestMethod]
+        [TestCategory("Registration")]
+        public void UnregisterConfigs_MultipleTypes_RemovesAll()
+        {
+            // Arrange
+            Token token = this.tokenService!.CreateToken();
+
+            Type[] types = [typeof(UnitTestAConfig), typeof(UnitTestBConfig)];
+
+            // Act
+            this.configService!.RegisterConfigs(types, ownerToken: token);
+            this.configService.UnregisterConfigs(types, token);
+
+            // Assert
+            foreach (Type type in types)
+                Assert.ThrowsException<ConfigTypeNotFoundException>(() =>
+                        this.configService.GetConfigInstance(type, token));
+        }
+
+        [TestMethod]
+        [TestCategory("Registration")]
+        public void UnregisterConfig_InvalidToken_ThrowsUnauthorizedAccessException()
+        {
+            // Arrange
+            Token token = this.tokenService!.CreateToken();
+            Token attackerToken = this.tokenService.CreateToken();
+
+            // Act
+            this.configService!.RegisterConfig(typeof(UnitTestAConfig), ownerToken: token);
+
+            // Assert
+            Assert.ThrowsException<UnauthorizedAccessException>(() =>
+                this.configService.UnregisterConfig(typeof(UnitTestAConfig), attackerToken));
+        }
+
+
+        #endregion
+
+        #region ConfigServiceTests: Accessors
+
+        [TestMethod]
+        [TestCategory("Accessors")]
+        public void GetConfigInstance_UnregisteredType_ThrowsInvalidOperationException()
+        {
+            // Arrange
+            Token token = this.tokenService!.CreateToken();
+
+            // Act & Assert
+            ConfigTypeNotFoundException ex = Assert.ThrowsException<ConfigTypeNotFoundException>(() =>
+                this.configService!.GetConfigInstance(typeof(UnitTestAConfig), token)
+            );
+
+            StringAssert.Contains(ex.Message, "not registered");
+        }
+
+        [TestMethod]
+        [TestCategory("Accessors")]
+        public void GetEnvConfig_ValidEnvironmentVariable_ReturnsExpectedValue()
+        {
+            string testKey = "TEST_ENV_VAR_" + Guid.NewGuid().ToString("N");
+            string expectedValue = "test_value_123";
+            Environment.SetEnvironmentVariable(testKey, expectedValue);
+
+            IConfiguration envConfig = this.configService!.GetEnvConfig();
+            string? actualValue = envConfig[testKey];
+
+            Environment.SetEnvironmentVariable(testKey, null);
+
+            Assert.AreEqual(expectedValue, actualValue);
+        }
+
+        [TestMethod]
+        [TestCategory("Accessors")]
+        public void GetEnvConfig_EnvironmentVariableChangedAfterRebuild_ReflectsUpdatedValue()
+        {
+            string testKey = "TEST_ENV_VAR_" + Guid.NewGuid().ToString("N");
+            string initialValue = "initial_value";
+            string updatedValue = "updated_value";
+            Environment.SetEnvironmentVariable(testKey, initialValue);
+
+            IConfiguration envConfig1 = this.configService!.GetEnvConfig();
+            string? actualValue1 = envConfig1[testKey];
+            Assert.AreEqual(initialValue, actualValue1);
+
+            Environment.SetEnvironmentVariable(testKey, updatedValue);
+
+            IConfiguration envConfig2 = this.configService.GetEnvConfig();
+            string? actualValue2 = envConfig2[testKey];
+
+            Environment.SetEnvironmentVariable(testKey, null);
+
+            Assert.AreEqual(updatedValue, actualValue2);
+        }
+
+        [TestCategory("Accessors")]
+        [DataTestMethod]
+        [DataRow(true, "test-value")]
+        [DataRow(false, null)]
+        public void GetSetting_ValidAndInvalidToken_EnforcesAccessAndThrowsWhenUnauthorized(bool useValidToken, string? expectedValue)
+        {
+            // Arrange
+            Token token = this.tokenService!.CreateToken();
+
+            // Act
+            this.configService!.RegisterConfig(typeof(UnitTestAConfig), readToken: token, writeToken: token);
+            this.configService.SetSetting(typeof(UnitTestAConfig), "FieldA", "test-value", writeToken: token);
+
+            // Assert
+            Token? accessToken = useValidToken ? token : Token.Blocked;
+
+            if (useValidToken)
+            {
+                string? result = this.configService.GetSetting<string>(typeof(UnitTestAConfig), "FieldA", readToken: accessToken);
+
+                Assert.AreEqual(expectedValue, result);
+            }
+            else
+            {
+                Assert.ThrowsException<UnauthorizedAccessException>(() =>
+                    this.configService.GetSetting<string>(typeof(UnitTestAConfig), "FieldA", accessToken)
+                );
+            }
+        }
+
+        #endregion
+
+        #region ConfigServiceTests: Mutators
+
+        [TestMethod]
+        [TestCategory("Mutators")]
+        public void SetSetting_RegisteredType_UpdatesValueAndFiresEvent()
+        {
+            // Arrange
+            bool eventFired = false;
+            this.configService!.SettingChanged += (s, e) => eventFired = true;
+
+            // Act
+            this.configService.RegisterConfigs([typeof(UnitTestAConfig)], writeToken: Token.Public);
+            this.configService.SetSetting(typeof(UnitTestAConfig), "FieldA", 85);
+
+            int value = this.configService.GetSetting<int>(typeof(UnitTestAConfig), "FieldA");
+
+            // Assert
+            Assert.AreEqual(85, value);
+            Assert.IsTrue(eventFired, "Setting changes should fire events");
+        }
+
+        [TestMethod]
+        [TestCategory("Mutators")]
+        public void SetSetting_UnregisteredType_ThrowsInvalidOperationException()
+        {
+            ConfigTypeNotFoundException ex = Assert.ThrowsException<ConfigTypeNotFoundException>(() =>
+                this.configService!.SetSetting(typeof(UnitTestAConfig), "FieldA", 80));
+
+            StringAssert.Contains(ex.Message, "Type configuration for");
+        }
+
+        [TestMethod]
+        [TestCategory("Mutators")]
+        public void SetSetting_TypeConversion_HandlesCorrectlyAndFiresEvent()
+        {
+            // Arrange
+            bool eventFired = false;
+            this.configService!.SettingChanged += (s, e) => eventFired = true;
+
+            // Act
+            this.configService.RegisterConfigs([typeof(UnitTestAConfig)], writeToken: Token.Public);
+            this.configService.SetSetting(typeof(UnitTestAConfig), "FieldA", 80);
+            this.configService.SetSetting(typeof(UnitTestAConfig), "FieldA", "90");
+
+            // Assert
+            Assert.IsTrue(eventFired, "Type change should fire event");
+            Assert.AreEqual("90", this.configService.GetSetting<string>(typeof(UnitTestAConfig), "FieldA"));
+        }
+
+        [TestCategory("Mutators")]
+        [DataTestMethod]
+        [DataRow("NewUserOverride", null, 90, 80, 90, true)]
+        [DataRow("RevertToBaseValue", 85, 80, 85, 80, true)]
+        [DataRow("ChangeExistingOverride", 75, 85, 75, 85, true)]
+        public void SetSetting_FieldAWithVariousUserValues_UpdatesCorrectlyAndFiresEventWithExpectedOldAndNewValues
+            (string scenario, int? initialUserValue, int setValue, int? expectedOldValue, int expectedNewValue, bool expectEvent)
+        {
+            // Arrange
+            bool eventFired = false;
+            ConfigServiceSettingChangeEventArgs? eventArgs = null;
+            this.configService!.SettingChanged += (s, e) =>
+            {
+                eventFired = true;
+                eventArgs = e;
+            };
+
+            string configPath = Path.Combine(this.msTestHelpers.TempDirectory, "UnitTestAConfig.DefaultSettings.json");
+            this.msTestHelpers.CreateTempFile("{\"FieldA\": 80, \"FieldB\": true}", configPath);
+
+            // Act
+            this.configService.RegisterConfig(typeof(UnitTestAConfig), writeToken: Token.Public);
+
+            if (initialUserValue.HasValue)
+                this.configService.SetSetting(typeof(UnitTestAConfig), "FieldA", initialUserValue.Value);
+
+            this.configService.SetSetting(typeof(UnitTestAConfig), "FieldA", setValue);
+
+            // Assert
+            if (expectEvent)
+            {
+                Assert.IsTrue(eventFired, $"Event should fire for scenario: {scenario}");
+                Assert.IsNotNull(eventArgs, "Event arguments should not be null");
+                Assert.AreEqual(typeof(UnitTestAConfig), eventArgs.ConfigType);
+                Assert.AreEqual("FieldA", eventArgs.Key);
+
+                Assert.IsNotNull(eventArgs.OldValue, "OldValue should not be null");
+                Assert.IsNotNull(eventArgs.NewValue, "NewValue should not be null");
+
+                string expectedOldStr = expectedOldValue.ToString() ?? string.Empty;
+                string actualOldStr = eventArgs.OldValue.ToString() ?? string.Empty;
+                string expectedNewStr = expectedNewValue.ToString() ?? string.Empty;
+                string actualNewStr = eventArgs.NewValue.ToString() ?? string.Empty;
+
+                Assert.AreEqual(expectedOldStr, actualOldStr, "Old value mismatch");
+                Assert.AreEqual(expectedNewStr, actualNewStr, "New value mismatch");
+            }
+            else
+            {
+                Assert.IsFalse(eventFired, $"Event should not fire for scenario: {scenario}");
+            }
+
+            int currentValue = this.configService.GetSetting<int>(typeof(UnitTestAConfig), "FieldA");
+            Assert.AreEqual(expectedNewValue, currentValue, $"Current value mismatch in scenario: {scenario}");
+        }
+
+        [TestMethod]
+        [TestCategory("Mutators")]
+        public void GetBaseConfigFileContents_FileNotFound_ThrowsInvalidOperationException()
+        {
+            // Arrnage
+            Token token = this.tokenService!.CreateToken();
+
+            // Act
+            this.configService!.RegisterConfig(typeof(UnitTestBConfig), writeToken: token, readToken: token);
+
+            // Assert
+            Assert.ThrowsException<ConfigTypeNotFoundException>(() =>
+                this.configService.GetDefaultConfigFileContents(typeof(UnitTestAConfig), token));
+        }
+
+        #endregion
+
+        #region ConfigServiceTests: Persistence
+
+        [TestMethod]
+        [TestCategory("Persistence")]
+        public async Task SaveConfigInstance_ValidToken_UpdatesSettings()
+        {
+            // Arrange
+            Token token = this.tokenService!.CreateToken();
+
+            this.configService!.RegisterConfig(typeof(UnitTestAConfig), readToken: token, writeToken: token);
+
+            // Act
+            UnitTestAConfig preSave = (UnitTestAConfig)this.configService.GetConfigInstance(typeof(UnitTestAConfig), readToken: token);
+            preSave.FieldA = 200;
+            preSave.FieldB = true;
+
+            await this.configService.SaveConfigInstanceAsync(typeof(UnitTestAConfig), preSave, writeToken: token);
+
+            UnitTestAConfig postSave = (UnitTestAConfig)this.configService.GetConfigInstance(typeof(UnitTestAConfig), readToken: token);
+
+            // Assert
+            Assert.AreEqual(200, postSave.FieldA);
+            Assert.IsTrue(postSave.FieldB);
+        }
+
+        [TestMethod]
+        [TestCategory("Persistence")]
+        public async Task SaveConfigInstance_NullConfig_ThrowsArgumentNullException()
+        {
+            // Arrange
+            Token token = this.tokenService!.CreateToken();
+
+            this.configService!.RegisterConfig(typeof(UnitTestAConfig), writeToken: token);
+
+            // Act & Assert
+            await Assert.ThrowsExceptionAsync<ArgumentNullException>(async () =>
+                await this.configService.SaveConfigInstanceAsync(typeof(UnitTestAConfig), null!, token)
+            );
+        }
+
+        [TestMethod]
+        [TestCategory("Persistence")]
+        public async Task SaveSettingsAsync_ValidConfigType_SavesToFiles()
+        {
+            // Arrange
+            string configPath = Path.Combine(this.msTestHelpers.TempDirectory, "UnitTestAConfig.UserSettings.json");
+
+            // Act
+            this.configService!.RegisterConfig(typeof(UnitTestAConfig), writeToken: Token.Public);
+            this.configService.SetSetting(typeof(UnitTestAConfig), "FieldB", true);
+
+            await this.configService.SaveSettingsAsync(typeof(UnitTestAConfig));
+
+            // Assert
+            Assert.IsTrue(File.Exists(configPath), "User settings file should be created");
+            string userJson = File.ReadAllText(configPath);
+            Assert.IsTrue(userJson.Contains("\"FieldB\": true") || userJson.Contains("\"FieldB\":true"),
+                "User settings should contain test value");
+        }
+
+        [TestMethod]
+        [TestCategory("Persistence")]
+        public async Task SaveSettingsAsync_UnregisteredConfigType_ThrowsNotFoundException()
+        {
+            ConfigTypeNotFoundException ex = await Assert.ThrowsExceptionAsync<ConfigTypeNotFoundException>(() =>
+                this.configService!.SaveSettingsAsync(typeof(UnitTestAConfig)));
+
+            StringAssert.Contains(ex.Message, "Type configuration for UnitTestAConfig was not registered.");
+        }
+
+        [TestMethod]
+        [TestCategory("Persistence")]
+        public async Task SaveSettingsAsync_EmptySettings_SavesValidJson()
+        {
+            // Arrange
+            this.configService!.RegisterConfig(typeof(UnitTestBConfig), writeToken: Token.Public);
+
+            string defaultPath = Path.Combine(this.msTestHelpers.TempDirectory, "UnitTestBConfig.DefaultSettings.json");
+            string userPath = Path.Combine(this.msTestHelpers.TempDirectory, "UnitTestBConfig.UserSettings.json");
+
+            // Act
+            await this.configService.SaveSettingsAsync(typeof(UnitTestBConfig));
+
+            string defaultJson = File.ReadAllText(defaultPath);
+            string userJson = File.ReadAllText(userPath);
+
+            // Assert
+            Assert.AreEqual(typeof(UnitTestBConfig).SerializeToJson(new JsonSerializerOptions
+            {
+                NumberHandling = JsonNumberHandling.WriteAsString,
+            }), defaultJson.Trim(), "Empty user settings should save the default");
+
+            Assert.AreEqual("{}", userJson.Trim(), "Empty deafult settings should save as {}");
+        }
+
+        [TestMethod]
+        [TestCategory("Persistence")]
+        public async Task GetBaseConfigFileContents_GenericType_SavesAndRetrievesContentSuccessfully()
+        {
+            // Arrange
+            ITokenSet tokenSet = this.tokenService!.CreateTokenSet();
+            string contents = "{ \"FieldA\": 99, \"FieldB\": true }";
+
+            // Act
+            this.configService!.RegisterConfig(typeof(UnitTestAConfig), tokenSet);
+
+            await this.configService.SaveDefaultConfigFileContentsAsync(typeof(UnitTestAConfig), contents, tokenSet);
+
+            string actual = this.configService.GetDefaultConfigFileContents(typeof(UnitTestAConfig), tokenSet);
+
+            // Assert
+            Assert.AreEqual(contents, actual);
+        }
+
+        [TestCategory("Persistence")]
+        [DataTestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
+        public async Task SaveDefaultConfigFileContentsAsync_MissingDirectory_CreatesDirectoryAndSavesFile(bool deleteDirectory)
+        {
+            // Arrange
+            ITokenSet tokenSet = this.tokenService!.CreateTokenSet();
+            this.configService!.RegisterConfig(typeof(UnitTestAConfig), tokenSet);
+
+            if (deleteDirectory && Directory.Exists(this.msTestHelpers.TempDirectory))
+                Directory.Delete(this.msTestHelpers.TempDirectory, recursive: true);
+            else
+                Directory.CreateDirectory(this.msTestHelpers.TempDirectory);
+
+            string contents = "{ \"FieldA\": 1, \"FieldB\": false }";
+            string settingPath = Path.Combine(this.msTestHelpers.TempDirectory, "UnitTestAConfig.DefaultSettings.json");
+
+            // Act
+            await this.configService.SaveDefaultConfigFileContentsAsync(typeof(UnitTestAConfig), contents, tokenSet);
+
+            // Assert
+            Assert.IsTrue(Directory.Exists(Path.GetDirectoryName(settingPath)), "Config directory should exist");
+            Assert.IsTrue(File.Exists(settingPath), "Config file should be created");
+            Assert.AreEqual(contents, File.ReadAllText(settingPath), "File content should match");
+        }
+
+        #endregion
+
+        #region ConfigServiceTests: Events
+
+        [TestMethod]
+        [TestCategory("Events")]
+        public async Task OnConfigChanged_ValidType_ReloadsSettings()
+        {
+            // Arrange
+            List<Type> configTypes = [typeof(UnitTestAConfig)];
+
+            string configPath = Path.Combine(this.msTestHelpers.TempDirectory, "UnitTestAConfig.DefaultSettings.json");
+
+            this.msTestHelpers.CreateTempFile("{\"FieldA\": 80, \"FieldB\": true}", configPath);
+            this.configService!.RegisterConfigs(configTypes, reloadOnChange: true);
+
+            TaskCompletionSource<bool> reloadCompleted = new();
+
+            this.configService.ConfigReloaded += (sender, e) =>
+            {
+                if (e.ConfigType == typeof(UnitTestAConfig))
+                    reloadCompleted.SetResult(true);
+            };
+
+            this.msTestHelpers.CreateTempFile("{\"FieldA\": 70, \"FieldB\": true}", configPath);
+
+            // Act
+            Task completedTask = await Task.WhenAny(reloadCompleted.Task, Task.Delay(2000));
+
+            // Assert
+            if (completedTask != reloadCompleted.Task)
+                Assert.Fail("TypeConfigurationReloaded event not raised within timeout");
+
+            Assert.AreEqual(70, this.configService.GetSetting<int>(typeof(UnitTestAConfig), "FieldA"));
+        }
+
+        [TestMethod]
+        [TestCategory("Events")]
+        public async Task OnConfigChanged_MultipleReloads_ProcessesSequentially()
+        {
+            // Arrange
+            List<Type> configTypes = [typeof(UnitTestAConfig)];
+
+            string configPath = Path.Combine(this.msTestHelpers.TempDirectory, "UnitTestAConfig.DefaultSettings.json");
+            this.msTestHelpers.CreateTempFile("{\"FieldA\": 80}", configPath);
+            this.configService!.RegisterConfigs(configTypes, reloadOnChange: true);
+
+            int reloadCount = 0;
+            List<int> data = [];
+
+            Queue<TaskCompletionSource<bool>> reloadQueue = new();
+
+            this.configService.ConfigReloaded += (s, e) =>
+            {
+                if (e.ConfigType == typeof(UnitTestAConfig))
+                {
+                    reloadCount++;
+
+                    if (reloadQueue.Count > 0)
+                        reloadQueue.Dequeue().SetResult(true);
+                }
+            };
+
+            // Act
+            for (int i = 0; i < 3; i++)
+            {
+                TaskCompletionSource<bool> reloadCompletion = new();
+                reloadQueue.Enqueue(reloadCompletion);
+
+                int newFieldA = 70 + i;
+                this.msTestHelpers.CreateTempFile($"{{\"FieldA\": {newFieldA}}}", configPath);
+
+                await Task.WhenAny(reloadCompletion.Task, Task.Delay(2000));
+
+                data.Add(this.configService.GetSetting<int>(typeof(UnitTestAConfig), "FieldA"));
+            }
+
+            // Assert
+            for (int i = 0; i < 3; i++)
+                Assert.AreEqual(data[i], 70 + i, $"FieldA mismatch after reload {i + 1}");
+
+            Assert.AreEqual(3, reloadCount, "Should have triggered 3 reload events");
+        }
+
+        [TestMethod]
+        [TestCategory("Events")]
+        public async Task BadReload_MalformedJson_DoesNotOverwriteSettings()
+        {
+            this.configService!.RegisterConfig(typeof(UnitTestAConfig), reloadOnChange: true);
+
+            int initial = this.configService.GetSetting<int>(typeof(UnitTestAConfig), nameof(UnitTestAConfig.FieldA), this.readToken);
+
+            string defaultPath = Path.Combine(this.msTestHelpers.TempDirectory, $"{nameof(UnitTestAConfig)}.DefaultSettings.json");
+
+            // Corrupt the file that the watcher is monitoring.
+            this.msTestHelpers.CreateTempFile("}{ not: json", defaultPath);
+
+            // Give the watcher a moment to react.
+            await Task.Delay(800);
+
+            int after = this.configService.GetSetting<int>(typeof(UnitTestAConfig), nameof(UnitTestAConfig.FieldA), this.readToken);
+
+            Assert.AreEqual(initial, after,
+                "Settings should remain unchanged when a reload encounters malformed JSON.");
+        }
+
+        #endregion
+
+        #region ConfigServiceTests: Security
+
+        [TestCategory("Security")]
+        [DataTestMethod]
+        [DataRow("SaveConfigInstance")]
+        [DataRow("GetBaseConfigFileContents")]
+        [DataRow("SaveDefaultConfigFileContents")]
+        [DataRow("SetSetting")]
+        public async Task SecurityCriticalOperations_InvalidToken_ThrowsUnauthorizedAccessException(string operationType)
+        {
+            // Arrange
+            ITokenSet validTokenSet = this.tokenService!.CreateTokenSet();
+            ITokenSet invalidTokenSet = this.tokenService.CreateTokenSet();
+
+            switch (operationType)
+            {
+                case "SaveConfigInstance":
+                    // Act
+                    this.configService!.RegisterConfig(typeof(UnitTestAConfig), validTokenSet);
+                    UnitTestAConfig updatedConfig = new() { FieldA = 200, FieldB = true };
+
+                    // Assert
+                    await Assert.ThrowsExceptionAsync<UnauthorizedAccessException>(() =>
+                        this.configService.SaveConfigInstanceAsync(typeof(UnitTestAConfig), updatedConfig, invalidTokenSet));
+                    break;
+
+                case "GetBaseConfigFileContents":
+                    // Act
+                    this.configService!.RegisterConfig(typeof(UnitTestAConfig), validTokenSet);
+                    await this.configService.SaveDefaultConfigFileContentsAsync(typeof(UnitTestAConfig), "{}", validTokenSet);
+
+                    // Assert
+                    Assert.ThrowsException<UnauthorizedAccessException>(() =>
+                        this.configService.GetDefaultConfigFileContents(typeof(UnitTestAConfig), invalidTokenSet));
+                    break;
+
+                case "SaveDefaultConfigFileContents":
+                    // Act
+                    this.configService!.RegisterConfig(typeof(UnitTestBConfig), validTokenSet);
+
+                    // Assert
+                    await Assert.ThrowsExceptionAsync<UnauthorizedAccessException>(() =>
+                        this.configService.SaveDefaultConfigFileContentsAsync(typeof(UnitTestBConfig), "{}", invalidTokenSet));
+                    break;
+
+                case "SetSetting":
+                    // Act
+                    this.configService!.RegisterConfig(typeof(UnitTestAConfig), validTokenSet);
+
+                    // Assert
+                    Assert.ThrowsException<UnauthorizedAccessException>(() =>
+                        this.configService.SetSetting(typeof(UnitTestAConfig), "ApiKey", "new-value", invalidTokenSet));
+                    break;
+            }
+        }
+
+        #endregion
+
+        #region ConfigServiceTests: Concurrency
+
+        [TestMethod]
+        [TestCategory("Concurrency")]
+        public async Task ConcurrentReadersWriters_DoNotThrow()
+        {
+            const int iterations = 200;
+            const int readerTasks = 6;
+            const int writerTasks = 4;
+
+            this.configService!.RegisterConfig(typeof(UnitTestAConfig), writeToken: Token.Public);
+
+            var writers = Enumerable.Range(0, writerTasks).Select(_ => Task.Run(() =>
+            {
+                for (int i = 0; i < iterations; i++)
+                    this.configService!.SetSetting(typeof(UnitTestAConfig), nameof(UnitTestAConfig.FieldA), i, this.writeToken);
+            }));
+
+            var readers = Enumerable.Range(0, readerTasks).Select(_ => Task.Run(() =>
+            {
+                for (int i = 0; i < iterations; i++)
+                    _ = this.configService!.GetSetting<int>(typeof(UnitTestAConfig), nameof(UnitTestAConfig.FieldA), this.readToken);
+            }));
+
+            await Task.WhenAll(writers.Concat(readers));
+
+            // Final sanity read – must succeed without throwing.
+            _ = this.configService!.GetSetting<int>(typeof(UnitTestAConfig), nameof(UnitTestAConfig.FieldA), this.readToken);
+        }
+
+        #endregion
+    }
+}

--- a/PlugHub/Accessors/ConfigAccessor.cs
+++ b/PlugHub/Accessors/ConfigAccessor.cs
@@ -1,0 +1,67 @@
+﻿using PlugHub.Models;
+using PlugHub.Shared.Interfaces.Accessors;
+using PlugHub.Shared.Interfaces.Services;
+using PlugHub.Shared.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PlugHub.Accessors
+{
+    public class ConfigAccessor(IConfigService configService, ITokenService tokenService, IList<Type> configTypes, Token ownerToken, Token readToken, Token writeToken)
+        : IConfigAccessor
+    {
+        public readonly IConfigService ConfigService = configService;
+        public readonly ITokenService TokenService = tokenService;
+        public readonly IList<Type> ConfigTypes = configTypes;
+        public readonly Token OwnerToken = ownerToken;
+        public readonly Token ReadToken = readToken;
+        public readonly Token WriteToken = writeToken;
+
+        public ConfigAccessor(IConfigService service, ITokenService tokenService, IList<Type> configTypes, TokenSet tokenSet)
+            : this(service, tokenService, configTypes, tokenSet.Owner, tokenSet.Read, tokenSet.Write) { }
+
+        public virtual IConfigAccessorFor<TConfig> For<TConfig>() where TConfig : class
+        {
+            if (!this.ConfigTypes.Contains(typeof(TConfig)))
+            {
+                throw new ConfigTypeNotFoundException(
+                    $"Configuration type {typeof(TConfig).Name} is not accessible. " +
+                    $"Available types: {string.Join(", ", this.ConfigTypes.Select(t => t.Name))}"
+                );
+            }
+            return new ConfigAccessorFor<TConfig>(this.ConfigService, this.TokenService, this.OwnerToken, this.ReadToken, this.WriteToken);
+        }
+    }
+
+    public class ConfigAccessorFor<TConfig>(IConfigService service, ITokenService tokenService, Token ownerToken, Token readToken, Token writeToken)
+        : IConfigAccessorFor<TConfig> where TConfig : class
+    {
+        public readonly IConfigService ConfigService = service;
+        public readonly ITokenService TokenService = tokenService;
+        public readonly Token OwnerToken = ownerToken;
+        public readonly Token ReadToken = readToken;
+        public readonly Token WriteToken = writeToken;
+
+        public ConfigAccessorFor(IConfigService service, ITokenService tokenService, TokenSet tokenSet)
+            : this(service, tokenService, tokenSet.Owner, tokenSet.Read, tokenSet.Write) { }
+
+        public virtual T Get<T>(string key)
+            => this.ConfigService.GetSetting<T>(typeof(TConfig), key, this.OwnerToken, this.ReadToken)!;
+        public virtual void Set<T>(string key, T value)
+            => this.ConfigService.SetSetting(typeof(TConfig), key, value, this.OwnerToken, this.WriteToken);
+        public virtual void Save()
+            => this.ConfigService.SaveSettings(typeof(TConfig), this.OwnerToken, this.WriteToken);
+        public virtual async Task SaveAsync(CancellationToken cancellationToken = default)
+            => await this.ConfigService.SaveSettingsAsync(typeof(TConfig), this.OwnerToken, this.WriteToken, cancellationToken);
+
+        public virtual TConfig Get()
+            => (TConfig)this.ConfigService.GetConfigInstance(typeof(TConfig), this.OwnerToken, this.ReadToken);
+        public virtual void Save(TConfig config)
+            => this.ConfigService.SaveConfigInstance(typeof(TConfig), config, this.OwnerToken, this.WriteToken);
+        public virtual async Task SaveAsync(TConfig config, CancellationToken cancellationToken = default)
+            => await this.ConfigService.SaveConfigInstanceAsync(typeof(TConfig), config, this.OwnerToken, this.WriteToken, cancellationToken);
+    }
+}

--- a/PlugHub/Services/ConfigService.cs
+++ b/PlugHub/Services/ConfigService.cs
@@ -1,0 +1,928 @@
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using PlugHub.Accessors;
+using PlugHub.Shared.Extensions;
+using PlugHub.Shared.Interfaces.Accessors;
+using PlugHub.Shared.Interfaces.Models;
+using PlugHub.Shared.Interfaces.Services;
+using PlugHub.Shared.Models;
+using PlugHub.Shared.Utility;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PlugHub.Services
+{
+    internal class ConfigServiceConfig(IConfiguration defaultConfig, IConfiguration userConfig, Dictionary<string, ConfigServiceSettingValue> values, JsonSerializerOptions? jsonOptions, Token ownerToken, Token readToken, Token writeToken, bool reloadOnChange)
+    {
+        public IConfiguration DefaultConfig = defaultConfig;
+        public IConfiguration UserConfig = userConfig;
+
+        public Token Owner = ownerToken;
+        public Token Read = readToken;
+        public Token Write = writeToken;
+
+        public bool ReloadOnChange = reloadOnChange;
+        public JsonSerializerOptions? JsonSerializerOptions = jsonOptions;
+
+        public IDisposable? DefaultOnChange;
+        public IDisposable? UserOnChange;
+
+        public Dictionary<string, ConfigServiceSettingValue> Values = values;
+    }
+    internal class ConfigServiceSettingValue(Type? valueType, object? defaultValue, object? userValue, bool readValue, bool writeValue)
+    {
+        public Type? ValueType { get; set; } = valueType;
+
+        public object? DefaultValue { get; set; } = defaultValue;
+        public object? UserValue { get; set; } = userValue;
+
+        public bool ReadAccess { get; set; } = readValue;
+        public bool WriteAccess { get; set; } = writeValue;
+    }
+
+
+    public class ConfigService : IConfigService, IDisposable
+    {
+        public event EventHandler<ConfigServiceSaveErrorEventArgs>? SyncSaveOpErrors;
+        public event EventHandler<ConfigServiceConfigReloadedEventArgs>? ConfigReloaded;
+        public event EventHandler<ConfigServiceSettingChangeEventArgs>? SettingChanged;
+
+        private readonly ILogger<IConfigService> logger;
+        private readonly ITokenService tokenService;
+
+        private readonly ConcurrentDictionary<Type, Timer> reloadTimers = new();
+        private readonly ConcurrentDictionary<Type, ConfigServiceConfig> configs = [];
+
+        private readonly JsonSerializerOptions jsonOptions;
+        private readonly string configRootDirectory;
+        private readonly string configUserDirectory;
+
+        private bool isDesposed = false;
+
+        private readonly ConcurrentDictionary<Type, ReaderWriterLockSlim> configLock = new();
+
+
+        public ConfigService(ILogger<IConfigService> logger, ITokenService tokenService, string configRootDirectory, string configUserDirectory)
+        {
+            this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            this.tokenService = tokenService;
+
+            this.configRootDirectory = configRootDirectory;
+            this.configUserDirectory = configUserDirectory;
+
+            this.jsonOptions ??= new JsonSerializerOptions
+            {
+                NumberHandling = JsonNumberHandling.WriteAsString
+            };
+        }
+
+
+        public IConfigAccessor CreateAccessor(Type configTypes, Token? ownerToken = null, Token? readToken = null, Token? writeToken = null)
+        {
+            return this.CreateAccessor([configTypes], ownerToken, readToken, writeToken);
+        }
+        public IConfigAccessor CreateAccessor(Type configType, ITokenSet tokenSet)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IConfigAccessor CreateAccessor(IList<Type> configTypes, Token? ownerToken = null, Token? readToken = null, Token? writeToken = null)
+        {
+            (Token nOwner, Token nRead, Token nWrite) = this.tokenService.CreateTokenSet(ownerToken, readToken, writeToken);
+
+            return new ConfigAccessor(this, this.tokenService, configTypes, nOwner, nRead, nWrite);
+        }
+        public IConfigAccessor CreateAccessor(IList<Type> configTypes, ITokenSet tokenSet)
+        {
+            throw new NotImplementedException();
+        }
+
+
+        public void RegisterConfig(Type configType, Token? ownerToken = null, Token? readToken = null, Token? writeToken = null, JsonSerializerOptions? jsonOptions = null, bool reloadOnChange = false)
+        {
+            (Token nOwner, Token nRead, Token nWrite) = this.tokenService.CreateTokenSet(ownerToken, readToken, writeToken);
+
+            ReaderWriterLockSlim rwLock = this.GetConfigTypeLock(configType);
+            rwLock.EnterWriteLock();
+
+            try
+            {
+                if (this.configs.ContainsKey(configType))
+                {
+                    throw new InvalidOperationException(
+                        $"Configuration for {configType.Name} is already registered. " +
+                        "Use UnregisterConfig before re-registering.");
+                }
+
+                string defaultConfigFilePath = this.GetDefaultSettingsPath(configType);
+                string userConfigFilePath = this.GetUserSettingsPath(configType);
+
+                this.EnsureFileExists(defaultConfigFilePath, configType, this.jsonOptions);
+                this.EnsureFileExists(userConfigFilePath, options: this.jsonOptions);
+
+                IConfiguration defaultConfig = BuildConfig(defaultConfigFilePath, reloadOnChange);
+                IConfiguration userConfig = BuildConfig(userConfigFilePath, reloadOnChange);
+
+                this.configs[configType] = new(
+                    defaultConfig,
+                    userConfig,
+                    BuildSettings(configType, defaultConfig, userConfig),
+                    jsonOptions ?? this.jsonOptions,
+                    nOwner,
+                    nRead,
+                    nWrite,
+                    reloadOnChange);
+
+                if (reloadOnChange)
+                {
+                    this.configs[configType].DefaultOnChange =
+                        defaultConfig.GetReloadToken().RegisterChangeCallback(this.OnConfigChanged, configType);
+
+                    this.configs[configType].UserOnChange =
+                        userConfig.GetReloadToken().RegisterChangeCallback(this.OnConfigChanged, configType);
+                }
+            }
+            finally { if (rwLock.IsWriteLockHeld) rwLock.ExitWriteLock(); }
+        }
+        public void RegisterConfig(Type configType, ITokenSet tokenSet, JsonSerializerOptions? jsonOptions = null, bool reloadOnChange = false)
+        {
+            this.RegisterConfig(configType, tokenSet?.Owner, tokenSet?.Read, tokenSet?.Write, jsonOptions, reloadOnChange);
+        }
+
+        public void RegisterConfigs(IEnumerable<Type> configTypes, Token? ownerToken = null, Token? readToken = null, Token? writeToken = null, JsonSerializerOptions? jsonOptions = null, bool reloadOnChange = false)
+        {
+            if (configTypes == null)
+                throw new ArgumentNullException(nameof(configTypes), "Configuration types collection cannot be null.");
+
+            foreach (Type configType in configTypes)
+                this.RegisterConfig(configType, ownerToken, readToken, writeToken, jsonOptions, reloadOnChange);
+        }
+        public void RegisterConfigs(IEnumerable<Type> configTypes, ITokenSet tokenSet, JsonSerializerOptions? jsonOptions = null, bool reloadOnChange = false)
+        {
+            this.RegisterConfigs(configTypes, tokenSet?.Owner, tokenSet?.Read, tokenSet?.Write, jsonOptions, reloadOnChange);
+        }
+
+
+        public void UnregisterConfig(Type configType, Token? token = null)
+        {
+            (Token nOwner, _, _) = this.tokenService.CreateTokenSet(token, null, null);
+
+            ReaderWriterLockSlim rwLock = this.GetConfigTypeLock(configType);
+            rwLock.EnterWriteLock();
+
+            try
+            {
+                if (!this.configs.TryGetValue(configType, out ConfigServiceConfig? config))
+                    throw new ConfigTypeNotFoundException($"Type configuration for {configType.Name} was not registered.");
+
+                this.tokenService.AllowAccess(config.Owner, null, nOwner, null);
+
+                config.DefaultOnChange?.Dispose();
+                config.UserOnChange?.Dispose();
+
+                this.configs.TryRemove(configType, out ConfigServiceConfig? _);
+            }
+            finally { if (rwLock.IsWriteLockHeld) rwLock.ExitWriteLock(); }
+
+            this.configLock.TryRemove(configType, out ReaderWriterLockSlim? configlock);
+
+            configlock?.Dispose();
+        }
+        public void UnregisterConfig(Type configType, ITokenSet tokenSet)
+        {
+            this.UnregisterConfig(configType, tokenSet.Owner);
+        }
+
+        public void UnregisterConfigs(IEnumerable<Type> configTypes, Token? token = null)
+        {
+            if (configTypes == null)
+                throw new ArgumentNullException(nameof(configTypes), "Configuration types collection cannot be null.");
+
+            foreach (Type configType in configTypes)
+                this.UnregisterConfig(configType, token);
+        }
+        public void UnregisterConfigs(IEnumerable<Type> configTypes, ITokenSet tokenSet)
+        {
+            this.UnregisterConfigs(configTypes, tokenSet.Owner);
+        }
+
+
+        public IConfiguration GetEnvConfig()
+        {
+            return new ConfigurationBuilder()
+                .SetBasePath(Directory.GetCurrentDirectory())
+                .AddEnvironmentVariables()
+                .AddCommandLine(Environment.GetCommandLineArgs())
+                .Build();
+        }
+
+
+        public T? GetDefault<T>(Type configType, string key, Token? ownerToken = null, Token? readToken = null)
+        {
+            (Token nOwner, Token nRead, _) = this.tokenService.CreateTokenSet(ownerToken, readToken, null);
+
+            ReaderWriterLockSlim rwLock = this.GetConfigTypeLock(configType);
+            rwLock.EnterReadLock();
+
+            try
+            {
+                if (!this.configs.TryGetValue(configType, out ConfigServiceConfig? config))
+                    throw new ConfigTypeNotFoundException(
+                        $"Type configuration for {configType.Name} was not registered.");
+
+                this.tokenService.AllowAccess(config.Owner, config.Read, nOwner, nRead);
+
+                if (!config.Values.TryGetValue(key, out ConfigServiceSettingValue? setting))
+                    throw new KeyNotFoundException($"Setting '{key}' not found in {configType.Name}.");
+
+                return CastStoredValue<T>(setting.DefaultValue);
+            }
+            finally { if (rwLock.IsReadLockHeld) rwLock.ExitReadLock(); }
+        }
+        public T? GetDefault<T>(Type configType, string key, ITokenSet tokenSet)
+        {
+            return this.GetDefault<T>(configType, key, tokenSet.Owner, tokenSet.Read);
+        }
+
+        public T? GetSetting<T>(Type configType, string key, Token? ownerToken = null, Token? readToken = null)
+        {
+            (Token nOwner, Token nRead, _) = this.tokenService.CreateTokenSet(ownerToken, readToken, null);
+
+            ReaderWriterLockSlim rwLock = this.GetConfigTypeLock(configType);
+            rwLock.EnterReadLock();
+
+            try
+            {
+                if (!this.configs.TryGetValue(configType, out ConfigServiceConfig? config))
+                    throw new ConfigTypeNotFoundException(
+                        $"Type configuration for {configType.Name} was not registered.");
+
+                this.tokenService.AllowAccess(config.Owner, config.Read, nOwner, nRead);
+
+                if (!config.Values.TryGetValue(key, out ConfigServiceSettingValue? setting))
+                    throw new KeyNotFoundException(
+                        $"Setting '{key}' not found in {configType.Name}.");
+
+                if (!setting.ReadAccess)
+                    throw new UnauthorizedAccessException($"Read access denied for '{key}'");
+
+                object? raw = setting.UserValue ?? setting.DefaultValue;
+
+                return CastStoredValue<T>(raw);
+            }
+            finally { if (rwLock.IsReadLockHeld) rwLock.ExitReadLock(); }
+        }
+        public T? GetSetting<T>(Type configType, string key, ITokenSet tokenSet)
+        {
+            return this.GetSetting<T>(configType, key, tokenSet.Owner, tokenSet.Read);
+        }
+
+        public void SetSetting<T>(Type configType, string key, T? newValue, Token? ownerToken = null, Token? writeToken = null)
+        {
+            (Token nOwner, _, Token nWrite) = this.tokenService.CreateTokenSet(ownerToken, null, writeToken);
+
+            ReaderWriterLockSlim rwLock = this.GetConfigTypeLock(configType);
+            rwLock.EnterWriteLock();
+
+            try
+            {
+                if (!this.configs.TryGetValue(configType, out ConfigServiceConfig? config))
+                    throw new ConfigTypeNotFoundException($"Type configuration for {configType.Name} was not registered.");
+
+                this.tokenService.AllowAccess(config.Owner, config.Write, nOwner, nWrite);
+
+                if (!config.Values.TryGetValue(key, out ConfigServiceSettingValue? settingValue))
+                    throw new KeyNotFoundException($"Setting '{key}' not found in {configType.Name}.");
+
+                if (!settingValue.WriteAccess)
+                    throw new UnauthorizedAccessException($"Write access denied for '{key}'");
+
+                object? oldValue = settingValue.UserValue ?? settingValue.DefaultValue;
+
+                bool isDefaultValue = false;
+
+                try
+                {
+                    if (settingValue.DefaultValue != null)
+                    {
+                        T defaultValue = settingValue.DefaultValue is T val ? val : (T)Convert.ChangeType(settingValue.DefaultValue, typeof(T));
+
+                        isDefaultValue = EqualityComparer<T>.Default.Equals(newValue, defaultValue);
+                    }
+                }
+                catch { /* Ignore conversion errors */ }
+
+
+                if (isDefaultValue)
+                {
+                    settingValue.UserValue = null;
+                }
+                else
+                {
+                    settingValue.UserValue = newValue;
+                }
+
+                SettingChanged?.Invoke(this, new ConfigServiceSettingChangeEventArgs(
+                    configType: configType,
+                    key: key,
+                    oldValue: oldValue,
+                    newValue: newValue
+                ));
+            }
+            finally { if (rwLock.IsWriteLockHeld) rwLock.ExitWriteLock(); }
+        }
+        public void SetSetting<T>(Type configType, string key, T? value, ITokenSet tokenSet)
+        {
+            this.SetSetting<T>(configType, key, value, tokenSet.Owner, tokenSet.Write);
+        }
+
+        public void SaveSettings(Type configType, Token? ownerToken = null, Token? writeToken = null)
+        {
+            (Token nOwner, _, Token nWrite) = this.tokenService.CreateTokenSet(ownerToken, null, writeToken);
+
+            Task.Run(async () =>
+            {
+                try
+                {
+                    if (!this.configs.TryGetValue(configType, out ConfigServiceConfig? config))
+                        throw new ConfigTypeNotFoundException($"Type configuration for {configType.Name} was not registered.");
+
+                    this.tokenService.AllowAccess(config.Owner, config.Write, nOwner, nWrite);
+
+                    await this.SaveSettingsAsync(configType, nOwner, nWrite);
+                }
+                catch (Exception ex)
+                {
+                    this.OnSaveOperationError(ex, ConfigSaveOperation.SaveSettings, configType);
+                }
+            });
+        }
+        public void SaveSettings(Type configType, ITokenSet tokenSet)
+        {
+            this.SaveSettings(configType, tokenSet.Owner, tokenSet.Write);
+        }
+
+        public async Task SaveSettingsAsync(Type configType, Token? ownerToken = null, Token? writeToken = null, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            (Token nOwner, _, Token nWrite) = this.tokenService.CreateTokenSet(ownerToken, null, writeToken);
+
+            Dictionary<string, object?> defaultSettings;
+            Dictionary<string, object?> userSettings;
+            string defaultPath;
+            string userPath;
+            JsonSerializerOptions jsonOpts;
+
+            ReaderWriterLockSlim rw = this.GetConfigTypeLock(configType);
+            rw.EnterWriteLock();
+
+            try
+            {
+                if (!this.configs.TryGetValue(configType, out ConfigServiceConfig? config))
+                    throw new ConfigTypeNotFoundException(
+                        $"Type configuration for {configType.Name} was not registered.");
+
+                this.tokenService.AllowAccess(config.Owner, config.Write, nOwner, nWrite);
+
+                defaultSettings = config.Values.ToDictionary(
+                    kvp => kvp.Key,
+                    kvp => kvp.Value.DefaultValue);
+
+                userSettings = config.Values
+                    .Where(kvp => kvp.Value.UserValue is not null)
+                    .ToDictionary(kvp => kvp.Key, kvp => kvp.Value.UserValue);
+
+                defaultPath = this.GetDefaultSettingsPath(configType);
+                userPath = this.GetUserSettingsPath(configType);
+                jsonOpts = config.JsonSerializerOptions ?? this.jsonOptions;
+            }
+            finally { if (rw.IsWriteLockHeld) rw.ExitWriteLock(); }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            try
+            {
+                await SaveSettingsToFileAsync(defaultPath, defaultSettings, jsonOpts, cancellationToken)
+                      .ConfigureAwait(false);
+
+                await SaveSettingsToFileAsync(userPath, userSettings, jsonOpts, cancellationToken)
+                      .ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                throw new IOException($"Failed to save settings for '{configType.Name}'.", ex);
+            }
+        }
+        public async Task SaveSettingsAsync(Type configType, ITokenSet tokenSet, CancellationToken cancellationToken = default)
+        {
+            await this.SaveSettingsAsync(configType, tokenSet.Owner, tokenSet.Write, cancellationToken);
+        }
+
+
+        public object GetConfigInstance(Type configType, Token? ownerToken = null, Token? readToken = null)
+        {
+            (Token nOwner, Token nRead, _) = this.tokenService.CreateTokenSet(ownerToken, readToken, null);
+
+            ReaderWriterLockSlim rwLock = this.GetConfigTypeLock(configType);
+            rwLock.EnterReadLock();
+
+            try
+            {
+                if (!this.configs.TryGetValue(configType, out ConfigServiceConfig? config))
+                    throw new ConfigTypeNotFoundException($"Type configuration for {configType.Name} was not registered.");
+
+                this.tokenService.AllowAccess(config.Owner, config.Read, nOwner, nRead);
+
+                object instance = Activator.CreateInstance(configType)
+                    ?? throw new InvalidOperationException($"Failed to create instance of {configType.Name}");
+
+                foreach (PropertyInfo prop in configType.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+                {
+                    if (!prop.CanWrite) continue;
+
+                    if (config.Values.TryGetValue(prop.Name, out ConfigServiceSettingValue? setting))
+                    {
+                        object? value = setting.UserValue ?? setting.DefaultValue;
+
+                        try
+                        {
+                            if (value == null)
+                            {
+                                if (!prop.PropertyType.IsValueType || Nullable.GetUnderlyingType(prop.PropertyType) != null)
+                                    prop.SetValue(instance, null);
+                                continue;
+                            }
+
+                            if (prop.PropertyType.IsEnum)
+                            {
+                                prop.SetValue(instance, Enum.IsDefined(prop.PropertyType, value)
+                                    ? Enum.ToObject(prop.PropertyType, value)
+                                    : Activator.CreateInstance(prop.PropertyType));
+                            }
+                            else if (prop.PropertyType.IsInstanceOfType(value))
+                            {
+                                prop.SetValue(instance, value);
+                            }
+                            else
+                            {
+                                prop.SetValue(instance,
+                                    Convert.ChangeType(value, Nullable.GetUnderlyingType(prop.PropertyType) ?? prop.PropertyType));
+                            }
+                        }
+                        catch (Exception ex) when (ex is InvalidCastException or FormatException or OverflowException)
+                        {
+                            this.logger.LogError(ex,
+                                "Failed to set property {PropertyName} for type {ConfigType}",
+                                prop.Name, configType.Name);
+                        }
+                    }
+                }
+
+                return instance;
+            }
+            finally { if (rwLock.IsReadLockHeld) rwLock.ExitReadLock(); }
+        }
+        public object GetConfigInstance(Type configType, ITokenSet tokenSet)
+        {
+            return this.GetConfigInstance(configType, tokenSet.Owner, tokenSet.Read);
+        }
+
+        public void SaveConfigInstance(Type configType, object updatedConfig, Token? ownerToken = null, Token? writeToken = null)
+        {
+            (Token nOwner, _, Token nWrite) = this.tokenService.CreateTokenSet(ownerToken, null, writeToken);
+
+            Task.Run(async () =>
+            {
+                try
+                {
+                    if (!this.configs.TryGetValue(configType, out ConfigServiceConfig? config))
+                        throw new ConfigTypeNotFoundException($"Type configuration for {configType.Name} was not registered.");
+
+                    this.tokenService.AllowAccess(config.Owner, config.Write, nOwner, nWrite);
+
+                    await this.SaveConfigInstanceAsync(configType, updatedConfig, nOwner, nWrite);
+                }
+                catch (Exception ex)
+                {
+                    this.OnSaveOperationError(ex, ConfigSaveOperation.SaveConfigInstance, configType);
+                }
+            });
+        }
+        public void SaveConfigInstance(Type configType, object updatedConfig, ITokenSet tokenSet)
+        {
+            this.SaveConfigInstance(configType, updatedConfig, tokenSet.Owner, tokenSet.Write);
+        }
+
+        public async Task SaveConfigInstanceAsync(Type configType, object updatedConfig, Token? ownerToken = null, Token? writeToken = null, CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(updatedConfig);
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            (Token nOwner, _, Token nWrite) = this.tokenService.CreateTokenSet(ownerToken, null, writeToken);
+
+            ReaderWriterLockSlim rwLock = this.GetConfigTypeLock(configType);
+            rwLock.EnterWriteLock();
+
+            try
+            {
+                if (!this.configs.TryGetValue(configType, out ConfigServiceConfig? config))
+                    throw new ConfigTypeNotFoundException($"Type configuration for {configType.Name} was not registered.");
+
+                this.tokenService.AllowAccess(config.Owner, config.Write, nOwner, nWrite);
+
+                foreach (PropertyInfo prop in configType.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+                {
+                    string key = prop.Name;
+                    object? newValue = prop.GetValue(updatedConfig);
+
+                    if (!config.Values.TryGetValue(key, out ConfigServiceSettingValue? setting))
+                        throw new KeyNotFoundException($"Property '{key}' not found in settings.");
+
+                    bool isDefaultValue = false;
+                    try
+                    {
+                        if (setting.DefaultValue != null)
+                        {
+                            isDefaultValue = object.Equals(newValue, setting.DefaultValue);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        this.logger.LogWarning(ex, "Comparison fallback failed for key '{Key}' on type {ConfigType}. Value: {Value}", key, configType.Name, newValue);
+                    }
+
+                    if (isDefaultValue)
+                    {
+                        setting.UserValue = null;
+                    }
+                    else
+                    {
+                        setting.UserValue = newValue;
+                    }
+                }
+            }
+            finally { if (rwLock.IsWriteLockHeld) rwLock.ExitWriteLock(); }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            await this.SaveSettingsAsync(configType, nOwner, nWrite, cancellationToken);
+        }
+        public async Task SaveConfigInstanceAsync(Type configType, object updatedConfig, ITokenSet tokenSet, CancellationToken cancellationToken = default)
+        {
+            await this.SaveConfigInstanceAsync(configType, updatedConfig, tokenSet.Owner, tokenSet.Write, cancellationToken);
+        }
+
+
+        public string GetDefaultConfigFileContents(Type configType, Token? ownerToken = null)
+        {
+            (Token nOwner, _, _) = this.tokenService.CreateTokenSet(ownerToken, null, null);
+
+            string filePath;
+
+            ReaderWriterLockSlim rwLock = this.GetConfigTypeLock(configType);
+            rwLock.EnterReadLock();
+
+            try
+            {
+                if (!this.configs.TryGetValue(configType, out ConfigServiceConfig? config))
+                    throw new ConfigTypeNotFoundException($"Type configuration for {configType.Name} was not registered.");
+
+                this.tokenService.AllowAccess(config.Owner, null, nOwner, null);
+            }
+            finally { if (rwLock.IsReadLockHeld) rwLock.ExitReadLock(); }
+
+            filePath = this.GetDefaultSettingsPath(configType);
+
+            if (!File.Exists(filePath))
+            {
+                throw new FileNotFoundException($"Default config file not found: {filePath}");
+            }
+
+            return File.ReadAllText(filePath);
+        }
+        public string GetDefaultConfigFileContents(Type configType, ITokenSet tokenSet)
+        {
+            return this.GetDefaultConfigFileContents(configType, tokenSet.Owner);
+        }
+
+        public void SaveDefaultConfigFileContents(Type configType, string contents, Token? ownerToken = null)
+        {
+            (Token nOwner, _, _) = this.tokenService.CreateTokenSet(ownerToken, null, null);
+
+            Task.Run(async () =>
+            {
+                try
+                {
+                    if (!this.configs.TryGetValue(configType, out ConfigServiceConfig? config))
+                        throw new ConfigTypeNotFoundException($"Type configuration for {configType.Name} was not registered.");
+
+                    this.tokenService.AllowAccess(config.Owner, null, nOwner, null);
+
+                    await this.SaveDefaultConfigFileContentsAsync(configType, contents, nOwner);
+                }
+                catch (Exception ex)
+                {
+                    this.OnSaveOperationError(ex, ConfigSaveOperation.SaveDefaultConfigFileContents, configType);
+                }
+            });
+        }
+        public void SaveDefaultConfigFileContents(Type configType, string contents, ITokenSet tokenSet)
+        {
+            this.SaveDefaultConfigFileContents(configType, contents, tokenSet.Owner);
+        }
+
+        public async Task SaveDefaultConfigFileContentsAsync(Type configType, string contents, Token? ownerToken = null, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            (Token nOwner, _, _) = this.tokenService.CreateTokenSet(ownerToken, null, null);
+
+            ReaderWriterLockSlim rwLock = this.GetConfigTypeLock(configType);
+            rwLock.EnterWriteLock();
+
+            try
+            {
+                if (!this.configs.TryGetValue(configType, out ConfigServiceConfig? config))
+                    throw new ConfigTypeNotFoundException($"Type configuration for {configType.Name} was not registered.");
+
+                this.tokenService.AllowAccess(config.Owner, null, nOwner, null);
+            }
+            finally { if (rwLock.IsWriteLockHeld) rwLock.ExitWriteLock(); }
+
+            string settingPath = this.GetDefaultSettingsPath(configType);
+
+            try
+            {
+                JsonDocument.Parse(contents);
+            }
+            catch (ArgumentException ex)
+            {
+                throw new ArgumentException($"Provided content was seen as an illegal argument.", ex);
+            }
+            catch (JsonException ex)
+            {
+                throw new UnauthorizedAccessException($"Provided content failed to parse as JSON. Please check your contents.", ex);
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            await Atomic.WriteAsync(settingPath, contents, cancellationToken: cancellationToken);
+        }
+        public async Task SaveDefaultConfigFileContentsAsync(Type configType, string contents, ITokenSet tokenSet, CancellationToken cancellationToken = default)
+        {
+            await this.SaveDefaultConfigFileContentsAsync(configType, contents, tokenSet.Owner, cancellationToken);
+        }
+
+        void IDisposable.Dispose()
+        {
+            if (this.isDesposed) return;
+
+            List<ReaderWriterLockSlim> locks = [.. this.configLock.Values];
+
+            foreach (ReaderWriterLockSlim l in locks) l.EnterWriteLock();
+
+            try
+            {
+                if (this.isDesposed) return;
+
+                foreach (Timer t in this.reloadTimers.Values)
+                    t.Dispose();
+                this.reloadTimers.Clear();
+
+                foreach (ConfigServiceConfig config in this.configs.Values)
+                {
+                    config.DefaultOnChange?.Dispose();
+                    config.UserOnChange?.Dispose();
+                }
+
+                this.configs.Clear();
+                this.isDesposed = true;
+            }
+            finally { foreach (ReaderWriterLockSlim l in locks) if (l.IsWriteLockHeld) l.ExitWriteLock(); }
+
+            foreach (ReaderWriterLockSlim l in this.configLock.Values)
+                l.Dispose();
+
+            GC.SuppressFinalize(this);
+        }
+
+
+        private void OnConfigChanged(object? state)
+        {
+            if (state is not Type configType)
+                return;
+
+            var timer = this.reloadTimers.GetOrAdd(configType, CreateDebounceTimer);
+
+            timer.Change(TimeSpan.FromMilliseconds(300), Timeout.InfiniteTimeSpan);
+
+            Timer CreateDebounceTimer(Type key)
+            {
+                return new Timer(
+                    _ => this.HandleReload(key),
+                    null,
+                    TimeSpan.FromMilliseconds(300),
+                    Timeout.InfiniteTimeSpan);
+            }
+        }
+        private void OnSaveOperationError(Exception ex, ConfigSaveOperation operation, Type configType)
+        {
+            this.SyncSaveOpErrors?.Invoke(this, new ConfigServiceSaveErrorEventArgs(ex, operation, configType));
+        }
+
+
+        private ReaderWriterLockSlim GetConfigTypeLock(Type sectionType)
+            => this.configLock.GetOrAdd(sectionType, _ => new ReaderWriterLockSlim());
+        private static T? CastStoredValue<T>(object? raw)
+        {
+            try
+            {
+                if (raw is T typed)
+                    return typed;
+
+                if (raw is IConvertible)
+                    return (T)Convert.ChangeType(raw, typeof(T));
+            }
+            catch (InvalidCastException) { }
+            catch (FormatException) { }
+            catch (OverflowException) { }
+
+            return default;
+        }
+        private void HandleReload(Type configType)
+        {
+            ConfigServiceConfig? config = null;
+
+            bool found = false;
+            bool reloaded = false;
+
+            ReaderWriterLockSlim rw = this.GetConfigTypeLock(configType);
+
+            rw.EnterWriteLock();
+
+            try
+            {
+                if (this.configs.TryGetValue(configType, out config))
+                {
+                    Dictionary<string, ConfigServiceSettingValue> newSettings =
+                        BuildSettings(configType, config.DefaultConfig, config.UserConfig);
+
+                    config.Values = newSettings;
+
+                    found = true;
+
+                    if (config.ReloadOnChange)
+                    {
+                        config.DefaultOnChange?.Dispose();
+                        config.UserOnChange?.Dispose();
+
+                        config.DefaultOnChange = config.DefaultConfig
+                            .GetReloadToken()
+                            .RegisterChangeCallback(this.OnConfigChanged, configType);
+
+                        config.UserOnChange = config.UserConfig
+                            .GetReloadToken()
+                            .RegisterChangeCallback(this.OnConfigChanged, configType);
+                    }
+
+                    reloaded = true;
+                }
+            }
+            catch (FileNotFoundException ex)
+            {
+                this.logger.LogWarning(ex, "Config directory missing – Type {Type}", configType.Name);
+            }
+            catch (Exception ex)
+            {
+                this.logger.LogError(ex, "Config reload failed – Type {Type}", configType.Name);
+            }
+            finally
+            {
+                if (rw.IsWriteLockHeld) rw.ExitWriteLock();
+            }
+
+            if (reloaded)
+                ConfigReloaded?.Invoke(this, new ConfigServiceConfigReloadedEventArgs(configType));
+
+            if (!found)
+                this.logger.LogWarning("Unregistered config type – Type {Type}", configType.Name);
+        }
+
+
+        private static void EnsureDirectoryExists(string filePath)
+        {
+            string? directory = Path.GetDirectoryName(filePath);
+
+            if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+                Directory.CreateDirectory(directory);
+        }
+        private void EnsureFileExists(string filePath, Type? configType = null, JsonSerializerOptions? options = null)
+        {
+            EnsureDirectoryExists(filePath);
+
+            if (!File.Exists(filePath))
+            {
+                try
+                {
+                    string content = "{}";
+
+                    if (configType != null)
+                        content = configType.SerializeToJson(options ?? this.jsonOptions);
+
+                    Atomic.Write(filePath, content);
+                }
+                catch (Exception ex)
+                {
+                    throw new IOException($"Failed to create the required configuration file at '{filePath}'.", ex);
+                }
+            }
+        }
+
+
+        private static IConfiguration BuildConfig(string filePath, bool reloadOnChange = false)
+        {
+            try
+            {
+                return new ConfigurationBuilder()
+                    .AddJsonFile(filePath, optional: true, reloadOnChange: reloadOnChange)
+                    .Build();
+            }
+            catch (Exception ex)
+            {
+                throw new IOException($"Failed to build configuration from file '{filePath}'.", ex);
+            }
+        }
+        private static Dictionary<string, ConfigServiceSettingValue> BuildSettings(Type configType, IConfiguration defaultConfig, IConfiguration userConfig)
+        {
+            Dictionary<string, ConfigServiceSettingValue> settings = [];
+            PropertyInfo[] properties = configType.GetProperties();
+
+            foreach (PropertyInfo prop in properties)
+            {
+                string key = prop.Name;
+
+                object? defaultValue = GetConfigurationValue(defaultConfig, key, prop.PropertyType);
+                object? userValue = GetConfigurationValue(userConfig, key, prop.PropertyType);
+
+                bool isReadable = prop.CanRead;
+                bool isWritable = prop.CanWrite;
+
+                settings[key] = new ConfigServiceSettingValue(
+                    valueType: prop.PropertyType,
+                    defaultValue: defaultValue,
+                    userValue: userValue,
+                    readValue: isReadable,
+                    writeValue: isWritable
+                );
+            }
+
+            return settings;
+        }
+        private static object? GetConfigurationValue(IConfiguration config, string key, Type targetType)
+        {
+            IConfigurationSection section = config.GetSection(key);
+            if (!section.Exists()) return null;
+
+            try
+            {
+                return section.Get(targetType);
+            }
+            catch
+            {
+                return Convert.ChangeType(section.Value, targetType);
+            }
+        }
+
+
+        private string GetDefaultSettingsPath(Type configType)
+            => Path.Combine(this.configRootDirectory, $"{configType.Name}.DefaultSettings.json");
+        private string GetUserSettingsPath(Type configType)
+            => Path.Combine(this.configUserDirectory, $"{configType.Name}.UserSettings.json");
+
+        private static async Task SaveSettingsToFileAsync(string filePath, Dictionary<string, object?> settings, JsonSerializerOptions options, CancellationToken cancellationToken = default)
+        {
+            string serialized;
+
+            try
+            {
+                serialized = JsonSerializer.Serialize(settings, options);
+            }
+            catch (NotSupportedException ex)
+            {
+                throw new InvalidOperationException("Failed to serialize the provided settings object.", ex);
+            }
+
+            await Atomic.WriteAsync(filePath, serialized, cancellationToken: cancellationToken);
+        }
+    }
+}


### PR DESCRIPTION
## Description

This PR introduces `ConfigService`, a secure, layered configuration management system for PlugHub applications and plugins.  
Key features include:
- Token-based authorization for all configuration operations
- Per-plugin configuration contexts with strict isolation
- Atomic file operations to prevent configuration corruption
- Granular event system for per-setting change tracking
- Type-safe configuration accessors for compile-time safety
- Comprehensive unit tests covering security, concurrency, and file I/O edge cases

## Related Issue

Resolves #11

## Motivation and Context

Modern plugin ecosystems require robust, secure, and flexible configuration management.  
This service:
- Prevents unauthorized access to sensitive settings via token-based security
- Supports multi-tenant scenarios with isolated, per-plugin configuration
- Ensures configuration integrity through atomic file operations
- Enables responsive, event-driven plugins with granular change tracking
- Provides a developer-friendly, type-safe API for configuration access

## How Has This Been Tested?

- Unit tests cover:
  - Token-based access control (valid/invalid/owner tokens)
  - Per-plugin isolation and registration/unregistration
  - Atomic file writes, concurrent readers/writers, and cancellation
  - Event firing on individual setting changes
  - Type safety and compile-time validation of accessors
  - Edge cases: malformed files, missing configs, unauthorized access, etc.
- Tests run on .NET 8
- All acceptance criteria from the task have been verified as met

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Asset change (adds or updates icons, templates, or other assets)
- [ ] Documentation change (adds or updates documentation)
- [ ] Plugin change (adds or updates a plugin)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My change requires a change to the core logic.
    - [x] I have linked the project issue above.
- [ ] My change requires a change to the assets.
    - [ ] I have linked the asset issue above.
- [ ] My change requires a change to the documentation.
    - [ ] I have linked the documentation issue above.
- [ ] My change requires a change to a plugin.
    - [ ] I have linked the plugin issue above.
