### PR TITLE
Moves Configuration Accessor Factory to Dependency Injection

### DIFF
--- a/PlugHub.Shared/Interfaces/Accessors/IConfigAccessor.cs
+++ b/PlugHub.Shared/Interfaces/Accessors/IConfigAccessor.cs
@@ -1,115 +1,64 @@
 ﻿using PlugHub.Shared.Interfaces.Services;
+using PlugHub.Shared.Models;
 
 namespace PlugHub.Shared.Interfaces.Accessors
 {
-    /// <summary>
-    /// Root entry-point into PlugHub’s configuration system.
-    /// </summary>
-    /// <remarks>
-    /// Call <see cref="For{TConfig}"/> to obtain an accessor that is specialised for a single
-    /// configuration POCO.  From that accessor you can read, mutate, and persist configuration
-    /// values while PlugHub handles default/user merge-logic, RBAC, and—in the secure pipeline—
-    /// automatic encryption.
-    /// </remarks>
+    /// <summary>Root entry-point into PlugHub’s configuration system.</summary>
     public interface IConfigAccessor
     {
-        /// <summary>
-        /// Returns a strongly-typed accessor for configuration section
-        /// <typeparamref name="TConfig"/>.
-        /// </summary>
-        /// <typeparam name="TConfig">
-        /// Class that models a configuration section (must be public and have a parameterless constructor).
-        /// </typeparam>
-        /// <returns>
-        /// An <see cref="IConfigAccessorFor{TConfig}"/> instance through which the caller can
-        /// <see cref="IConfigAccessorFor{TConfig}.Get{T}(string)"/> / 
-        /// <see cref="IConfigAccessorFor{TConfig}.Set{T}(string,T)"/> individual keys,
-        /// or load / save an entire <typeparamref name="TConfig"/> object.
-        /// </returns>
-        /// <exception cref="ConfigTypeNotFoundException">
-        /// Thrown when <typeparamref name="TConfig"/> has not been registered with the
-        /// configuration service.
-        /// </exception>
-        IConfigAccessorFor<TConfig> For<TConfig>() where TConfig : class;
+        public IConfigAccessor Init(IList<Type> configTypes, Token? ownerToken, Token? readToken, Token? writeToken);
+
+        /// <summary>Returns a strongly-typed accessor for <typeparamref name="TConfig"/>.</summary>
+        /// <typeparam name="TConfig">Configuration POCO (public, parameter-less ctor).</typeparam>
+        /// <returns>IConfigAccessorFor&lt;TConfig&gt; scoped to the requested section.</returns>
+        /// <exception cref="ConfigTypeNotFoundException">Type not registered.</exception>
+        public IConfigAccessorFor<TConfig> For<TConfig>() where TConfig : class;
     }
 
-    /// <summary>
-    /// Provides fine-grained, type-safe access to a single configuration class of type <typeparamref name="TConfig"/>.
-    /// Supports key-level reads/writes with compile-time type validation and whole-object operations
-    /// including retrieval, merging, and persistence. Includes synchronous and asynchronous save methods.
-    /// </summary>
-    /// <typeparam name="TConfig">The POCO representing the configuration section</typeparam>
+    /// <summary>Type-safe accessor for a single configuration class.</summary>
+    /// <typeparam name="TConfig">Configuration POCO.</typeparam>
     public interface IConfigAccessorFor<TConfig> where TConfig : class
     {
         /// <summary>
-        /// Fetches the current *effective* value for <paramref name="key"/> and converts it
-        /// to <typeparamref name="T"/>.
+        /// <summary>Gets the default <paramref name="key"/> as <typeparamref name="T"/>.</summary>
         /// </summary>
-        /// <typeparam name="T">Desired return type.</typeparam>
-        /// <param name="key">Public property name on <typeparamref name="TConfig"/>.</param>
-        /// <returns>The merged (user ⮕ default) value converted to <typeparamref name="T"/>.</returns>
-        /// <exception cref="KeyNotFoundException">
-        /// Thrown when the property does not exist in <typeparamref name="TConfig"/>.
-        /// </exception>
-        T Get<T>(string key);
+        /// <typeparam name="T">Return type.</typeparam>
+        /// <param name="key">Public property name.</param>
+        /// <returns>Current default value.</returns>
+        /// <exception cref="KeyNotFoundException"/>
+        /// <exception cref="InvalidCastException"/>
+        public T Default<T>(string key);
 
-        /// <summary>
-        /// Assigns <paramref name="value"/> to <paramref name="key"/> in memory.
-        /// </summary>
-        /// <remarks>
-        /// The change is *not* flushed to disk until one of the <c>Save*</c> methods is
-        /// invoked.  For secure properties the value is encrypted automatically before it
-        /// leaves the accessor.
-        /// </remarks>
-        /// <typeparam name="T">Type of the value being stored.</typeparam>
-        /// <param name="key">Public property name on <typeparamref name="TConfig"/>.</param>
-        void Set<T>(string key, T value);
+        /// <summary>Gets the effective <paramref name="key"/> as <typeparamref name="T"/>.</summary>
+        /// <typeparam name="T">Return type.</typeparam>
+        /// <param name="key">Public property name.</param>
+        /// <returns>Current merged value.</returns>
+        /// <exception cref="KeyNotFoundException">Property not found.</exception>
+        public T Get<T>(string key);
 
-        /// <summary>
-        /// Synchronously writes all pending per-key edits to the user-scope configuration
-        /// file.  
-        /// Only keys whose value differs from the default are written, so the file contains
-        /// nothing but user overrides.
-        /// </summary>
-        /// <remarks>Blocks the calling thread for the duration of the file I/O.</remarks>
-        void Save();
+        /// <summary>Sets <paramref name="value"/> on <paramref name="key"/> in memory.</summary>
+        /// <typeparam name="T">Value type.</typeparam>
+        /// <param name="key">Public property name.</param>
+        /// <param name="value">New value (encrypted transparently if secure).</param>
+        public void Set<T>(string key, T value);
 
-        /// <summary>
-        /// Asynchronous counterpart of <see cref="Save"/>.  
-        /// Use this in UI or high-throughput code paths to avoid blocking.
-        /// </summary>
-        Task SaveAsync(CancellationToken cancellationToken = default);
+        /// <summary>Flushes pending edits to disk (blocking).</summary>
+        public void Save();
 
-        /// <summary>
-        /// Builds and returns the fully merged <typeparamref name="TConfig"/> instance that
-        /// the current caller would observe—i.e. <c>user&nbsp;overrides&nbsp;⇾&nbsp;default</c>.
-        /// </summary>
-        TConfig Get();
+        /// <summary>Flushes pending edits to disk asynchronously.</summary>
+        public Task SaveAsync(CancellationToken cancellationToken = default);
 
-        /// <summary>
-        /// Writes every property of <paramref name="config"/> to the user configuration
-        /// file using PlugHub’s merge rules.
-        /// </summary>
-        /// <param name="config">Fully populated configuration object.</param>
-        /// <remarks>
-        /// <list type="bullet">
-        ///   <item><description>
-        ///     Properties whose value equals the default are **omitted** (existing overrides
-        ///     are removed).
-        ///   </description></item>
-        ///   <item><description>
-        ///     Properties flagged as secure are persisted as encrypted Base-64 strings.
-        ///   </description></item>
-        /// </list>
-        /// This synchronous overload blocks until the write is complete; use
-        /// <see cref="SaveAsync(TConfig)"/> to perform the same operation asynchronously.
-        /// </remarks>
-        void Save(TConfig config);
 
-        /// <summary>
-        /// Asynchronous variant of <see cref="Save(TConfig)"/> that performs the comparison,
-        /// optional encryption, and disk write without blocking the calling thread.
-        /// </summary>
-        Task SaveAsync(TConfig config, CancellationToken cancellationToken = default);
+        /// <summary>Returns the fully merged <typeparamref name="TConfig"/> object.</summary>
+        public TConfig Get();
+
+        /// <summary>Saves the supplied <paramref name="config"/> to disk (blocking).</summary>
+        /// <param name="config">Updated configuration instance.</param>
+        public void Save(TConfig config);
+
+        /// <summary>Saves <paramref name="config"/> asynchronously.</summary>
+        /// <param name="config">Updated configuration instance.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        public Task SaveAsync(TConfig config, CancellationToken cancellationToken = default);
     }
 }

--- a/PlugHub.Shared/Interfaces/Services/IConfigService.cs
+++ b/PlugHub.Shared/Interfaces/Services/IConfigService.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.Extensions.Configuration;
-using PlugHub.Shared.Interfaces.Accessors;
 using PlugHub.Shared.Interfaces.Models;
 using PlugHub.Shared.Models;
 using System.Text.Json;
@@ -140,56 +139,6 @@ namespace PlugHub.Shared.Interfaces.Services
 
 
         /// <summary>
-        /// Creates an <see cref="IConfigAccessor"/> for a single configuration type,
-        /// using dedicated tokens for access control operations.
-        /// </summary>
-        /// <param name="configType">The configuration type to access.</param>
-        /// <param name="ownerToken">Optional token for owner operations. Defaults to a new <see cref="Token"/> if not specified.</param>
-        /// <param name="readToken">Optional token for read operations. Defaults to <see cref="Token.Public"/> if not specified.</param>
-        /// <param name="writeToken">Optional token for write operations. Defaults to <see cref="Token.Blocked"/> if not specified.</param>
-        /// <returns>
-        /// An <see cref="IConfigAccessor"/> scoped to the specified type and tokens.
-        /// </returns>
-        public IConfigAccessor CreateAccessor(Type configType, Token? ownerToken = null, Token? readToken = null, Token? writeToken = null);
-
-        /// <summary>
-        /// Creates an <see cref="IConfigAccessor"/> for a single configuration type,
-        /// using dedicated tokens for access control operations.
-        /// </summary>
-        /// <param name="configType">The configuration type to access.</param>
-        /// <param name="tokenSet">Consolidated token container for owner/read/write permissions.</param>
-        /// <returns>
-        /// An <see cref="IConfigAccessor"/> scoped to the specified type and tokens.
-        /// </returns>
-        public IConfigAccessor CreateAccessor(Type configType, ITokenSet tokenSet);
-
-
-        /// <summary>
-        /// Creates an <see cref="IConfigAccessor"/> for multiple configuration types,
-        /// using the specified tokens for access control.
-        /// </summary>
-        /// <param name="configTypes">The configuration types to access.</param>
-        /// <param name="ownerToken">Optional token for owner operations. Defaults to a new <see cref="Token"/> if not specified.</param>
-        /// <param name="readToken">Optional token for read operations. Defaults to <see cref="Token.Public"/> if not specified.</param>
-        /// <param name="writeToken">Optional token for write operations. Defaults to <see cref="Token.Blocked"/> if not specified.</param>
-        /// <returns>
-        /// An <see cref="IConfigAccessor"/> scoped to the specified types and tokens.
-        /// </returns>
-        public IConfigAccessor CreateAccessor(IList<Type> configTypes, Token? ownerToken = null, Token? readToken = null, Token? writeToken = null);
-
-        /// <summary>
-        /// Creates an <see cref="IConfigAccessor"/> for multiple configuration types,
-        /// using the specified tokens for access control.
-        /// </summary>
-        /// <param name="configTypes">The configuration types to access.</param>
-        /// <param name="tokenSet">Consolidated token container for owner/read/write permissions.</param>
-        /// <returns>
-        /// An <see cref="IConfigAccessor"/> scoped to the specified types and tokens.
-        /// </returns>
-        public IConfigAccessor CreateAccessor(IList<Type> configTypes, ITokenSet tokenSet);
-
-
-        /// <summary>
         /// Registers a configuration type with granular token-based access control and type-specific JSON serialization settings.
         /// </summary>
         /// <param name="configType">The type representing the configuration.</param>
@@ -202,23 +151,18 @@ namespace PlugHub.Shared.Interfaces.Services
         public void RegisterConfig(Type configType, Token? ownerToken = null, Token? readToken = null, Token? writeToken = null, JsonSerializerOptions? jsonOptions = null, bool reloadOnChange = false);
 
         /// <summary>
-        /// Registers a configuration type using a token set for consolidated access control,
-        /// with type-specific JSON serialization settings and change reloading.
+        /// Registers a configuration type with granular token-based access control and type-specific JSON serialization settings.
         /// </summary>
         /// <param name="configType">The type representing the configuration structure.</param>
         /// <param name="tokenSet">Consolidated token container for owner/read/write permissions.</param>
         /// <param name="jsonOptions">Custom JSON serialization settings for this configuration type, overriding global options for property naming, converters, and formatting.</param>
         /// <param name="reloadOnChange">Enables automatic reloading when underlying configuration files change.</param>
-        /// <exception cref="UnauthorizedAccessException">Thrown when invalid tokens are provided</exception>
-        /// <remarks>
-        /// Provides a consolidated interface for token management while maintaining identical security 
-        /// and serialization behavior as the granular token overload.
-        /// </remarks>
+        /// <exception cref="UnauthorizedAccessException"/>
         public void RegisterConfig(Type configType, ITokenSet tokenSet, JsonSerializerOptions? jsonOptions = null, bool reloadOnChange = false);
 
 
         /// <summary>
-        /// Registers multiple configuration types with shared token policies and type-specific JSON serialization settings.
+        /// Registers a configuration type with granular token-based access control and type-specific JSON serialization settings.
         /// </summary>
         /// <param name="configTypes">The types representing configurations.</param>
         /// <param name="ownerToken">Optional token for owner operations. Defaults to a new <see cref="Token"/> if not specified.</param>
@@ -230,13 +174,13 @@ namespace PlugHub.Shared.Interfaces.Services
         public void RegisterConfigs(IEnumerable<Type> configTypes, Token? ownerToken = null, Token? readToken = null, Token? writeToken = null, JsonSerializerOptions? jsonOptions = null, bool reloadOnChange = false);
 
         /// <summary>
-        /// Registers multiple configuration types using a consolidated token set for access control, with optional JSON serialization settings.
+        /// Registers a configuration type with granular token-based access control and type-specific JSON serialization settings.
         /// </summary>
         /// <param name="configTypes">The configuration types to register.</param>
         /// <param name="tokenSet">Consolidated token container for owner/read/write permissions.</param>
         /// <param name="jsonOptions">Custom JSON serialization settings applied to all specified configuration types.</param>
         /// <param name="reloadOnChange">Enables automatic reload when underlying configuration files change.</param>
-        /// <exception cref="UnauthorizedAccessException">Thrown if current context lacks permission to register configurations.</exception>
+        /// <exception cref="UnauthorizedAccessException"/>
         public void RegisterConfigs(IEnumerable<Type> configTypes, ITokenSet tokenSet, JsonSerializerOptions? jsonOptions = null, bool reloadOnChange = false);
 
 
@@ -245,11 +189,7 @@ namespace PlugHub.Shared.Interfaces.Services
         /// </summary>
         /// <param name="configType">The <see cref="Type"/> of the configuration to unregister.</param>
         /// <param name="ownerToken">Optional token for owner operations. Defaults to a new <see cref="Token"/> if not specified.</param>
-        /// <exception cref="UnauthorizedAccessException">Thrown if the provided token does not have write access to the configuration.</exception>
-        /// <remarks>
-        /// This method is thread-safe. If the configuration type is not registered, the operation is a no-op.
-        /// Any registered reload callbacks for the configuration will be disposed.
-        /// </remarks>
+        /// <exception cref="UnauthorizedAccessException"/>
         public void UnregisterConfig(Type configType, Token? ownerToken = null);
 
         /// <summary>
@@ -257,11 +197,7 @@ namespace PlugHub.Shared.Interfaces.Services
         /// </summary>
         /// <param name="configType">The <see cref="Type"/> of the configuration to unregister.</param>
         /// <param name="tokenSet">Consolidated token container for owner/read/write permissions.</param>
-        /// <exception cref="UnauthorizedAccessException">Thrown if the provided token does not have write access to the configuration.</exception>
-        /// <remarks>
-        /// This method is thread-safe. If the configuration type is not registered, the operation is a no-op.
-        /// Any registered reload callbacks for the configuration will be disposed.
-        /// </remarks>
+        /// <exception cref="UnauthorizedAccessException"/>
         public void UnregisterConfig(Type configType, ITokenSet tokenSet);
 
 
@@ -270,12 +206,8 @@ namespace PlugHub.Shared.Interfaces.Services
         /// </summary>
         /// <param name="configTypes">A collection of <see cref="Type"/> objects representing the configurations to unregister.</param>
         /// <param name="ownerToken">Optional token for owner operations. Defaults to a new <see cref="Token"/> if not specified.</param>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="configTypes"/> is null.</exception>
-        /// <exception cref="UnauthorizedAccessException">Thrown if the provided token does not have write access to any configuration in the collection.</exception>
-        /// <remarks>
-        /// This method is thread-safe. If a configuration type in the collection is not registered, it is skipped.
-        /// Any registered reload callbacks for each configuration will be disposed.
-        /// </remarks>
+        /// <exception cref="ArgumentNullException"/>
+        /// <exception cref="UnauthorizedAccessException"/>
         public void UnregisterConfigs(IEnumerable<Type> configTypes, Token? ownerToken = null);
 
         /// <summary>
@@ -283,12 +215,8 @@ namespace PlugHub.Shared.Interfaces.Services
         /// </summary>
         /// <param name="configTypes">A collection of <see cref="Type"/> objects representing the configurations to unregister.</param>
         /// <param name="tokenSet">Consolidated token container for owner/read/write permissions.</param>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="configTypes"/> is null.</exception>
-        /// <exception cref="UnauthorizedAccessException">Thrown if the provided token does not have write access to any configuration in the collection.</exception>
-        /// <remarks>
-        /// This method is thread-safe. If a configuration type in the collection is not registered, it is skipped.
-        /// Any registered reload callbacks for each configuration will be disposed.
-        /// </remarks>
+        /// <exception cref="ArgumentNullException"/>
+        /// <exception cref="UnauthorizedAccessException"/>
         public void UnregisterConfigs(IEnumerable<Type> configTypes, ITokenSet tokenSet);
 
 
@@ -335,14 +263,6 @@ namespace PlugHub.Shared.Interfaces.Services
         /// <param name="configType">The configuration type whose default config file should be overwritten.</param>
         /// <param name="contents">The raw JSON contents to write to the default config file.</param>
         /// <param name="ownerToken">Optional token for owner operations. Defaults to a new <see cref="Token"/> if not specified.</param>
-        /// <param name="writeToken">Optional token for write operations. Defaults to <see cref="Token.Blocked"/> if not specified.</param>
-        /// Optional access token for write authorization. If not specified, defaults to <see cref="Token.Public"/>.
-        /// </param>
-        /// <remarks>
-        /// - This is a fire-and-forget operation; exceptions are not thrown synchronously.
-        /// - Errors that occur during the write are surfaced via the <see cref="SyncSaveOpErrors"/> event handler.
-        /// - Use <see cref="SaveDefaultConfigFileContentsAsync"/> for awaitable, exception-aware saving.
-        /// </remarks>
         public void SaveDefaultConfigFileContents(Type configType, string contents, Token? ownerToken = null);
 
         /// <summary>
@@ -351,14 +271,7 @@ namespace PlugHub.Shared.Interfaces.Services
         /// </summary>
         /// <param name="configType">The configuration type whose default config file should be overwritten.</param>
         /// <param name="contents">The raw JSON contents to write to the default config file.</param>
-        /// <param name="tokenSet">Consolidated token container for owner/read/write permissions.</param>
-        /// Optional access token for write authorization. If not specified, defaults to <see cref="Token.Public"/>.
-        /// </param>
-        /// <remarks>
-        /// - This is a fire-and-forget operation; exceptions are not thrown synchronously.
-        /// - Errors that occur during the write are surfaced via the <see cref="SyncSaveOpErrors"/> event handler.
-        /// - Use <see cref="SaveDefaultConfigFileContentsAsync"/> for awaitable, exception-aware saving.
-        /// </remarks>
+        /// <param name="tokenSet">Consolidated token container for owner/read/write permissions.</param>        
         public void SaveDefaultConfigFileContents(Type configType, string contents, ITokenSet tokenSet);
 
 
@@ -371,8 +284,8 @@ namespace PlugHub.Shared.Interfaces.Services
         /// <param name="ownerToken">Optional token for owner operations. Defaults to a new <see cref="Token"/> if not specified.</param>
         /// <param name="readToken">Optional token for read operations. Defaults to <see cref="Token.Public"/> if not specified.</param>
         /// <returns>A populated instance of the requested configuration type</returns>
-        /// <exception cref="KeyNotFoundException">Thrown if configType is not registered</exception>
-        /// <exception cref="InvalidOperationException">Thrown if instance creation fails</exception>
+        /// <exception cref="KeyNotFoundException"/>
+        /// <exception cref="InvalidOperationException"/>
         public object GetConfigInstance(Type configType, Token? ownerToken = null, Token? readToken = null);
 
         /// <summary>
@@ -383,8 +296,8 @@ namespace PlugHub.Shared.Interfaces.Services
         /// <param name="configType">The Type of configuration class to retrieve</param>
         /// <param name="tokenSet">Consolidated token container for owner/read/write permissions.</param>
         /// <returns>A populated instance of the requested configuration type</returns>
-        /// <exception cref="KeyNotFoundException">Thrown if configType is not registered</exception>
-        /// <exception cref="InvalidOperationException">Thrown if instance creation fails</exception>
+        /// <exception cref="KeyNotFoundException"/>
+        /// <exception cref="InvalidOperationException"/>
         public object GetConfigInstance(Type configType, ITokenSet tokenSet);
 
 
@@ -397,7 +310,7 @@ namespace PlugHub.Shared.Interfaces.Services
         /// <param name="updatedConfig">Instance containing new property values</param>
         /// <param name="ownerToken">Optional token for owner operations. Defaults to a new <see cref="Token"/> if not specified.</param>
         /// <param name="writeToken">Optional token for write operations. Defaults to <see cref="Token.Blocked"/> if not specified.</param>
-        /// <exception cref="ArgumentNullException">Thrown if updatedConfig is null</exception>
+        /// <exception cref="ArgumentNullException"/>
         public Task SaveConfigInstanceAsync(Type configType, object updatedConfig, Token? ownerToken = null, Token? writeToken = null, CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -408,7 +321,7 @@ namespace PlugHub.Shared.Interfaces.Services
         /// <param name="configType">The Type of configuration being updated</param>
         /// <param name="updatedConfig">Instance containing new property values</param>
         /// <param name="tokenSet">Consolidated token container for owner/read/write permissions.</param>
-        /// <exception cref="ArgumentNullException">Thrown if updatedConfig is null</exception>
+        /// <exception cref="ArgumentNullException"/>
         public Task SaveConfigInstanceAsync(Type configType, object updatedConfig, ITokenSet tokenSet, CancellationToken cancellationToken = default);
 
 
@@ -420,13 +333,6 @@ namespace PlugHub.Shared.Interfaces.Services
         /// <param name="updatedConfig">The updated configuration object to persist.</param>
         /// <param name="ownerToken">Optional token for owner operations. Defaults to a new <see cref="Token"/> if not specified.</param>
         /// <param name="writeToken">Optional token for write operations. Defaults to <see cref="Token.Blocked"/> if not specified.</param>
-        /// Optional access token for write authorization. If not specified, defaults to <see cref="Token.Public"/>.
-        /// </param>
-        /// <remarks>
-        /// - This is a fire-and-forget operation; exceptions are not thrown synchronously.
-        /// - Errors that occur during the save are surfaced via the <see cref="SyncSaveOpErrors"/> event handler.
-        /// - Use <see cref="SaveConfigInstanceAsync"/> for awaitable, exception-aware saving.
-        /// </remarks>
         public void SaveConfigInstance(Type configType, object updatedConfig, Token? ownerToken = null, Token? writeToken = null);
 
         /// <summary>
@@ -436,13 +342,6 @@ namespace PlugHub.Shared.Interfaces.Services
         /// <param name="configType">The configuration type whose settings should be updated.</param>
         /// <param name="updatedConfig">The updated configuration object to persist.</param>
         /// <param name="tokenSet">Consolidated token container for owner/read/write permissions.</param>
-        /// Optional access token for write authorization. If not specified, defaults to <see cref="Token.Public"/>.
-        /// </param>
-        /// <remarks>
-        /// - This is a fire-and-forget operation; exceptions are not thrown synchronously.
-        /// - Errors that occur during the save are surfaced via the <see cref="SyncSaveOpErrors"/> event handler.
-        /// - Use <see cref="SaveConfigInstanceAsync"/> for awaitable, exception-aware saving.
-        /// </remarks>
         public void SaveConfigInstance(Type configType, object updatedConfig, ITokenSet tokenSet);
 
 
@@ -455,7 +354,6 @@ namespace PlugHub.Shared.Interfaces.Services
 
         /// <summary>
         /// Returns the *baseline* value that was loaded from
-        /// <c>&lt;{configType.Name}&gt;.DefaultSettings.json</c> for the property named
         /// <paramref name="key"/> – ignoring any user-override that might currently exist.
         /// </summary>
         /// <typeparam name="T">Desired return type.  If the stored object implements <see cref="IConvertible"/> it is converted to <typeparamref name="T"/>; otherwise the method attempts a direct cast.</typeparam>
@@ -464,18 +362,12 @@ namespace PlugHub.Shared.Interfaces.Services
         /// <param name="ownerToken">Optional token for owner operations. Defaults to a new <see cref="Token"/> if not specified.</param>
         /// <param name="readToken">Optional token for read operations. Defaults to <see cref="Token.Public"/> if not specified.</param>
         /// <returns> The default value converted to <typeparamref name="T"/>; <see langword="default"/> when the conversion cannot be performed.</returns>
-        /// <exception cref="ConfigTypeNotFoundException">Thrown when <paramref name="configType"/> has not been registered.</exception>
-        /// <exception cref="KeyNotFoundException">Thrown when the supplied <paramref name="key"/> does not exist in the defaults file.</exception>
-        /// <remarks>
-        /// For properties marked *secure*, the return value is a <c>SecureValue</c> instance
-        /// containing the encrypted Base-64 payload.
-        /// The method is crypto-agnostic; no decryption occurs inside <c>ConfigService</c>.
-        /// </remarks>
+        /// <exception cref="ConfigTypeNotFoundException"/>
+        /// <exception cref="KeyNotFoundException"/>
         T? GetDefault<T>(Type configType, string key, Token? ownerToken = null, Token? readToken = null);
 
         /// <summary>
         /// Returns the *baseline* value that was loaded from
-        /// <c>&lt;{configType.Name}&gt;.DefaultSettings.json</c> for the property named
         /// <paramref name="key"/> – ignoring any user-override that might currently exist.
         /// </summary>
         /// <typeparam name="T">Desired return type.  If the stored object implements <see cref="IConvertible"/> it is converted to <typeparamref name="T"/>; otherwise the method attempts a direct cast.</typeparam>
@@ -483,19 +375,13 @@ namespace PlugHub.Shared.Interfaces.Services
         /// <param name="key">Public property name declared on <paramref name="configType"/>.</param>
         /// <param name="tokenSet">Consolidated token container for owner/read/write permissions.</param>
         /// <returns> The default value converted to <typeparamref name="T"/>; <see langword="default"/> when the conversion cannot be performed.</returns>
-        /// <exception cref="ConfigTypeNotFoundException">Thrown when <paramref name="configType"/> has not been registered.</exception>
-        /// <exception cref="KeyNotFoundException">Thrown when the supplied <paramref name="key"/> does not exist in the defaults file.</exception>
-        /// <remarks>
-        /// For properties marked *secure*, the return value is a <c>SecureValue</c> instance
-        /// containing the encrypted Base-64 payload.
-        /// The method is crypto-agnostic; no decryption occurs inside <c>ConfigService</c>.
-        /// </remarks>
+        /// <exception cref="ConfigTypeNotFoundException"/>
+        /// <exception cref="KeyNotFoundException"/>
         T? GetDefault<T>(Type configType, string key, ITokenSet tokenSet);
 
 
         /// <summary>
-        /// Returns the *effective* value for the property named <paramref name="key"/>,
-        /// i.e.&nbsp;<c>UserValue ?? DefaultValue</c>, using the merge order defined by PlugHub.
+        /// Returns the *effective* value for the property named <paramref name="key"/>
         /// </summary>
         /// <typeparam name="T">Desired return type. If the stored object implements <see cref="IConvertible"/>, it is converted to <typeparamref name="T"/>; otherwise the method attempts a direct cast.</typeparam>
         /// <param name="configType">CLR type that models the configuration section you want to query.Must have been registered with the configuration service.</param>
@@ -503,33 +389,22 @@ namespace PlugHub.Shared.Interfaces.Services
         /// <param name="ownerToken">Optional token for owner operations. Defaults to a new <see cref="Token"/> if not specified.</param>
         /// <param name="readToken">Optional token for read operations. Defaults to <see cref="Token.Public"/> if not specified.</param>
         /// <returns>The effective value converted to <typeparamref name="T"/>; <see langword="default"/> when the conversion cannot be performed.</returns>
-        /// <exception cref="ConfigTypeNotFoundException">Thrown when <paramref name="configType"/> has not been registered.</exception>
-        /// <exception cref="KeyNotFoundException">Thrown when the supplied <paramref name="key"/> does not exist in the configuration.</exception>
-        /// <exception cref="UnauthorizedAccessException">Thrown when the caller, as identified by <paramref name="readToken"/>, does not have read access to the requested setting.</exception>
-        /// <remarks>
-        /// For properties marked *secure*, the returned value is a <c>SecureValue</c> object
-        /// containing the encrypted Base-64 payload unless the caller explicitly requests a
-        /// decrypted type via a secure accessor.
-        /// </remarks>
+        /// <exception cref="ConfigTypeNotFoundException"/>
+        /// <exception cref="KeyNotFoundException"/>
+        /// <exception cref="UnauthorizedAccessException"/>
         public T? GetSetting<T>(Type configType, string key, Token? ownerToken = null, Token? readToken = null);
 
         /// <summary>
-        /// Returns the *effective* value for the property named <paramref name="key"/>,
-        /// i.e.&nbsp;<c>UserValue ?? DefaultValue</c>, using the merge order defined by PlugHub.
+        /// Returns the *effective* value for the property named <paramref name="key"/>
         /// </summary>
         /// <typeparam name="T">Desired return type. If the stored object implements <see cref="IConvertible"/>, it is converted to <typeparamref name="T"/>; otherwise the method attempts a direct cast.</typeparam>
         /// <param name="configType">CLR type that models the configuration section you want to query.Must have been registered with the configuration service.</param>
         /// <param name="key">Public property name declared on <paramref name="configType"/>.</param>
         /// <param name="tokenSet">Consolidated token container for owner/read/write permissions.</param>
         /// <returns>The effective value converted to <typeparamref name="T"/>; <see langword="default"/> when the conversion cannot be performed.</returns>
-        /// <exception cref="ConfigTypeNotFoundException">Thrown when <paramref name="configType"/> has not been registered.</exception>
-        /// <exception cref="KeyNotFoundException">Thrown when the supplied <paramref name="key"/> does not exist in the configuration.</exception>
-        /// <exception cref="UnauthorizedAccessException">Thrown when the caller, as identified by <paramref name="readToken"/>, does not have read access to the requested setting.</exception>
-        /// <remarks>
-        /// For properties marked *secure*, the returned value is a <c>SecureValue</c> object
-        /// containing the encrypted Base-64 payload unless the caller explicitly requests a
-        /// decrypted type via a secure accessor.
-        /// </remarks>
+        /// <exception cref="ConfigTypeNotFoundException"/>
+        /// <exception cref="KeyNotFoundException"/>
+        /// <exception cref="UnauthorizedAccessException"/>
         public T? GetSetting<T>(Type configType, string key, ITokenSet tokenSet);
 
 
@@ -561,14 +436,7 @@ namespace PlugHub.Shared.Interfaces.Services
         /// </summary>
         /// <param name="configType">The configuration type whose settings should be saved.</param>
         /// <param name="ownerToken">Optional token for owner operations. Defaults to a new <see cref="Token"/> if not specified.</param>
-        /// <param name="writeToken">Optional token for write operations. Defaults to <see cref="Token.Blocked"/> if not specified.</param>
-        /// Optional access token for write authorization. If not specified, defaults to <see cref="Token.Public"/>.
-        /// </param>
-        /// <remarks>
-        /// - This is a fire-and-forget operation; exceptions are not thrown synchronously.
-        /// - Errors that occur during the save are surfaced via the <see cref="SyncSaveOpErrors"/> event handler.
-        /// - Use <see cref="SaveSettingsAsync"/> for awaitable, exception-aware saving.
-        /// </remarks>
+        /// <param name="writeToken">Optional token for write operations. Defaults to <see cref="Token.Blocked"/> if not specified.</param>        
         public void SaveSettings(Type configType, Token? ownerToken = null, Token? writeToken = null);
 
         /// <summary>
@@ -577,13 +445,6 @@ namespace PlugHub.Shared.Interfaces.Services
         /// </summary>
         /// <param name="configType">The configuration type whose settings should be saved.</param>
         /// <param name="tokenSet">Consolidated token container for owner/read/write permissions.</param>
-        /// Optional access token for write authorization. If not specified, defaults to <see cref="Token.Public"/>.
-        /// </param>
-        /// <remarks>
-        /// - This is a fire-and-forget operation; exceptions are not thrown synchronously.
-        /// - Errors that occur during the save are surfaced via the <see cref="SyncSaveOpErrors"/> event handler.
-        /// - Use <see cref="SaveSettingsAsync"/> for awaitable, exception-aware saving.
-        /// </remarks>
         public void SaveSettings(Type configType, ITokenSet tokenSet);
 
 

--- a/PlugHub.UnitTests/Accessors/ConfigAccessorTests.cs
+++ b/PlugHub.UnitTests/Accessors/ConfigAccessorTests.cs
@@ -56,13 +56,8 @@ namespace PlugHub.UnitTests.Accessors
         public void For_UnregisteredType_Throws()
         {
             // Arrange & Act
-            ConfigAccessor accessor = new(
-                this.configService!,
-                this.tokenService!,
-                [typeof(UnitTestAConfig)],
-                this.tokenService!.CreateToken(),
-                Token.Public,
-                Token.Public);
+            IConfigAccessor accessor = new ConfigAccessor(this.configService!)
+                .Init([typeof(UnitTestAConfig)], this.tokenService!.CreateToken(), Token.Public, Token.Public);
 
             // Assert
             Assert.ThrowsException<ConfigTypeNotFoundException>(() => accessor.For<UnitTestBConfig>());
@@ -74,13 +69,9 @@ namespace PlugHub.UnitTests.Accessors
         {
             // Arrange
             this.configService!.RegisterConfig(typeof(UnitTestAConfig));
-            ConfigAccessor accessor = new(
-                this.configService,
-                this.tokenService!,
-                [typeof(UnitTestAConfig)],
-                this.tokenService!.CreateToken(),
-                Token.Public,
-                Token.Public);
+
+            IConfigAccessor accessor = new ConfigAccessor(this.configService!)
+                .Init([typeof(UnitTestAConfig)], this.tokenService!.CreateToken(), Token.Public, Token.Public);
 
             // Act
             IConfigAccessorFor<UnitTestAConfig> stronglyTyped = accessor.For<UnitTestAConfig>();
@@ -99,13 +90,9 @@ namespace PlugHub.UnitTests.Accessors
         {
             //Arrange
             this.configService!.RegisterConfig(typeof(UnitTestAConfig));
-            ConfigAccessor accessor = new(
-                this.configService,
-                this.tokenService!,
-                [typeof(UnitTestAConfig)],
-                this.tokenService!.CreateToken(),
-                Token.Public,
-                Token.Public);
+
+            IConfigAccessor accessor = new ConfigAccessor(this.configService!)
+                .Init([typeof(UnitTestAConfig)], this.tokenService!.CreateToken(), Token.Public, Token.Public);
 
             IConfigAccessorFor<UnitTestAConfig> a = accessor.For<UnitTestAConfig>();
 
@@ -128,7 +115,9 @@ namespace PlugHub.UnitTests.Accessors
             this.configService!.RegisterConfig(typeof(UnitTestAConfig), owner, read, write);
             this.configService.SetSetting(typeof(UnitTestAConfig), nameof(UnitTestAConfig.FieldA), 99, writeToken: write);
 
-            ConfigAccessor accessor = new(this.configService, this.tokenService, [typeof(UnitTestAConfig)], owner, read, write);
+            IConfigAccessor accessor = new ConfigAccessor(this.configService!)
+                .Init([typeof(UnitTestAConfig)], owner, read, write);
+
             IConfigAccessorFor<UnitTestAConfig> aConfig = accessor.For<UnitTestAConfig>();
 
             // Act
@@ -148,10 +137,12 @@ namespace PlugHub.UnitTests.Accessors
             Token owner = this.tokenService!.CreateToken();
             Token read = this.tokenService!.CreateToken();
             Token write = this.tokenService!.CreateToken();
-            this.configService!.RegisterConfig(typeof(UnitTestAConfig), readToken: read, writeToken: write);
+            this.configService!.RegisterConfig(typeof(UnitTestAConfig), owner, read, write);
 
             // Act
-            ConfigAccessor accessor = new(this.configService, this.tokenService, [typeof(UnitTestAConfig)], owner, read, write);
+            IConfigAccessor accessor = new ConfigAccessor(this.configService!)
+                .Init([typeof(UnitTestAConfig)], this.tokenService!.CreateToken(), read, write);
+
             IConfigAccessorFor<UnitTestAConfig> config = accessor.For<UnitTestAConfig>();
 
             // Assert
@@ -173,13 +164,8 @@ namespace PlugHub.UnitTests.Accessors
             // Act
             this.configService!.RegisterConfig(typeof(UnitTestAConfig), readToken: read, writeToken: write);
 
-            ConfigAccessor accessor = new(
-                this.configService,
-                this.tokenService,
-                [typeof(UnitTestAConfig)],
-                this.tokenService.CreateToken(),
-                read,
-                write);
+            IConfigAccessor accessor = new ConfigAccessor(this.configService!)
+                .Init([typeof(UnitTestAConfig)], this.tokenService!.CreateToken(), read, write);
 
             IConfigAccessorFor<UnitTestAConfig> a = accessor.For<UnitTestAConfig>();
 
@@ -201,7 +187,9 @@ namespace PlugHub.UnitTests.Accessors
             Token write = this.tokenService.CreateToken();
             this.configService!.RegisterConfig(typeof(UnitTestAConfig), owner, read, write);
 
-            ConfigAccessor accessor = new(this.configService, this.tokenService, [typeof(UnitTestAConfig)], owner, read, write);
+            IConfigAccessor accessor = new ConfigAccessor(this.configService!)
+                .Init([typeof(UnitTestAConfig)], owner, read, write);
+
             IConfigAccessorFor<UnitTestAConfig> aConfig = accessor.For<UnitTestAConfig>();
 
             UnitTestAConfig editable = aConfig.Get();
@@ -231,10 +219,13 @@ namespace PlugHub.UnitTests.Accessors
             Token owner = this.tokenService!.CreateToken();
             Token read = this.tokenService!.CreateToken();
             Token write = this.tokenService.CreateToken();
-            this.configService!.RegisterConfig(typeof(UnitTestAConfig), readToken: read, writeToken: write);
+
+            this.configService!.RegisterConfig(typeof(UnitTestAConfig), owner, read, write);
 
             // Act
-            ConfigAccessor accessor = new(this.configService, this.tokenService, [typeof(UnitTestAConfig)], owner, read, Token.Public);
+            IConfigAccessor accessor = new ConfigAccessor(this.configService!)
+                .Init([typeof(UnitTestAConfig)], this.tokenService.CreateToken(), read, Token.Public);
+
             IConfigAccessorFor<UnitTestAConfig> aConfig = accessor.For<UnitTestAConfig>();
 
             UnitTestAConfig edited = aConfig.Get();
@@ -253,10 +244,13 @@ namespace PlugHub.UnitTests.Accessors
             Token owner = this.tokenService!.CreateToken();
             Token read = this.tokenService!.CreateToken();
             Token write = this.tokenService!.CreateToken();
-            this.configService!.RegisterConfig(typeof(UnitTestAConfig), readToken: read, writeToken: write);
+
+            this.configService!.RegisterConfig(typeof(UnitTestAConfig), owner, read, write);
 
             // Act
-            ConfigAccessor accessor = new(this.configService, this.tokenService, [typeof(UnitTestAConfig)], owner, read, write);
+            IConfigAccessor accessor = new ConfigAccessor(this.configService!)
+                .Init([typeof(UnitTestAConfig)], this.tokenService.CreateToken(), Token.Public, write);
+
             IConfigAccessorFor<UnitTestAConfig> config = accessor.For<UnitTestAConfig>();
 
             // Assert
@@ -269,7 +263,7 @@ namespace PlugHub.UnitTests.Accessors
 
         [TestMethod]
         [TestCategory("Persistence")]
-        public async Task SaveAsync_PersistsToconfigService()
+        public async Task SaveAsync_PersistsToConfigService()
         {
             // Arrange
             Token read = this.tokenService!.CreateToken();
@@ -277,13 +271,8 @@ namespace PlugHub.UnitTests.Accessors
             this.configService!.RegisterConfig(typeof(UnitTestAConfig), readToken: read, writeToken: write);
 
             // Act
-            ConfigAccessor accessor = new(
-                this.configService,
-                this.tokenService,
-                [typeof(UnitTestAConfig)],
-                this.tokenService.CreateToken(),
-                read,
-                write);
+            IConfigAccessor accessor = new ConfigAccessor(this.configService!)
+                .Init([typeof(UnitTestAConfig)], this.tokenService!.CreateToken(), read, write);
 
             IConfigAccessorFor<UnitTestAConfig> a = accessor.For<UnitTestAConfig>();
 
@@ -306,13 +295,8 @@ namespace PlugHub.UnitTests.Accessors
             Token write = this.tokenService.CreateToken();
             this.configService!.RegisterConfig(typeof(UnitTestAConfig), readToken: read, writeToken: write);
 
-            ConfigAccessor accessor = new(
-                this.configService,
-                this.tokenService,
-                [typeof(UnitTestAConfig)],
-                this.tokenService.CreateToken(),
-                read,
-                write);
+            IConfigAccessor accessor = new ConfigAccessor(this.configService!)
+                .Init([typeof(UnitTestAConfig)], this.tokenService!.CreateToken(), read, write);
 
             IConfigAccessorFor<UnitTestAConfig> a = accessor.For<UnitTestAConfig>();
             a.Set(nameof(UnitTestAConfig.FieldA), 9001);
@@ -343,13 +327,8 @@ namespace PlugHub.UnitTests.Accessors
             Token write = this.tokenService.CreateToken();
             this.configService!.RegisterConfig(typeof(UnitTestAConfig), readToken: read, writeToken: write);
 
-            ConfigAccessor accessor = new(
-                this.configService,
-                this.tokenService,
-                [typeof(UnitTestAConfig)],
-                this.tokenService.CreateToken(),
-                read,
-                write);
+            IConfigAccessor accessor = new ConfigAccessor(this.configService!)
+                .Init([typeof(UnitTestAConfig)], this.tokenService!.CreateToken(), read, write);
 
             IConfigAccessorFor<UnitTestAConfig> a = accessor.For<UnitTestAConfig>();
             a.Set(nameof(UnitTestAConfig.FieldA), 424242);
@@ -403,13 +382,8 @@ namespace PlugHub.UnitTests.Accessors
             this.configService!.RegisterConfig(typeof(UnitTestAConfig), readToken: read, writeToken: write);
 
             // Act
-            ConfigAccessor accessor = new(
-                this.configService,
-                this.tokenService,
-                [typeof(UnitTestAConfig)],
-                this.tokenService.CreateToken(),
-                read,
-                Token.Public);
+            IConfigAccessor accessor = new ConfigAccessor(this.configService!)
+                .Init([typeof(UnitTestAConfig)], this.tokenService!.CreateToken(), Token.Public, Token.Public);
 
             IConfigAccessorFor<UnitTestAConfig> a = accessor.For<UnitTestAConfig>();
 
@@ -429,8 +403,12 @@ namespace PlugHub.UnitTests.Accessors
             Token owner = this.tokenService!.CreateToken();
             Token read = this.tokenService!.CreateToken();
             Token write = this.tokenService!.CreateToken();
+
             this.configService!.RegisterConfig(typeof(UnitTestAConfig), readToken: read, writeToken: write);
-            ConfigAccessor accessor = new(this.configService, this.tokenService, [typeof(UnitTestAConfig)], owner, read, write);
+
+            IConfigAccessor accessor = new ConfigAccessor(this.configService!)
+                .Init([typeof(UnitTestAConfig)], owner, read, write);
+
             IConfigAccessorFor<UnitTestAConfig> config = accessor.For<UnitTestAConfig>();
 
             // Act

--- a/PlugHub/App.axaml.cs
+++ b/PlugHub/App.axaml.cs
@@ -6,7 +6,9 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using PlugHub.Accessors;
 using PlugHub.Services;
+using PlugHub.Shared.Interfaces.Accessors;
 using PlugHub.Shared.Interfaces.Services;
 using PlugHub.Shared.Models;
 using PlugHub.ViewModels;
@@ -84,6 +86,7 @@ public partial class App : Application
     {
         services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
         services.AddSingleton<ITokenService, TokenService>();
+        services.AddTransient<IConfigAccessor, ConfigAccessor>();
 
         services.AddSingleton<IConfigService>(provider =>
         {


### PR DESCRIPTION
## Description

This PR refactors the configuration accessor creation process to leverage dependency injection (DI) for instantiation, removing all factory logic from the service layer. Accessors are now provided directly by DI, ensuring that all dependencies (tokens, config types, services) are resolved and injected automatically. Factory methods and overloads have been eliminated from the configuration service, which now only manages registration and configuration type/token management.

Key changes:
- **Removed all factory methods** from `IConfigService` and related interfaces.
- **Registered accessor types and dependencies** with the DI container.
- **Updated all consumers** to request accessors via DI, not manual construction or service factories.
- **Reduced API surface area** for easier, safer consumption and improved testability.

## Related Issue

resolves #25

## Motivation and Context

Previously, configuration accessors were created through service-layer factory methods, which increased coupling and made testing more difficult. By moving construction to DI:
- The codebase is now more modular and testable—accessors can be mocked or swapped easily.
- Responsibilities are clearly separated: the service manages registration, DI handles instantiation.
- The API is easier to use, with fewer overloads and less manual wiring.
- The system is more maintainable, extensible, and aligned with modern .NET practices[1].

## How Has This Been Tested?

- Updated all unit and integration tests to use DI for accessor resolution.
- Confirmed that no code paths remain that use the old factory methods.
- Ran regression tests to ensure no breaking changes in configuration behavior.

## Screenshots (if appropriate):

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Asset change (adds or updates icons, templates, or other assets)
- [ ] Documentation change (adds or updates documentation)
- [ ] Plugin change (adds or updates a plugin)

## Checklist

- [x] I have read the **CONTRIBUTING** document.
- [x] My change requires a change to the core logic.
    - [x] I have linked the project issue above.
- [ ] My change requires a change to the assets.
    - [ ] I have linked the asset issue above.
- [ ] My change requires a change to the documentation.
    - [ ] I have linked the documentation issue above.
- [ ] My change requires a change to a plugin.
    - [ ] I have linked the plugin issue above.