### PR TITLE
Implements Secure, Pluggable Storage of Sensitive Application Data

### DIFF
--- a/PlugHub.Shared/Interfaces/Platform/Storage/ISecureStorage.cs
+++ b/PlugHub.Shared/Interfaces/Platform/Storage/ISecureStorage.cs
@@ -1,0 +1,47 @@
+﻿namespace PlugHub.Shared.Interfaces.Platform.Storage
+{
+    public sealed record SecureStorageChangedEventArgs(string Id, SecureStorageChangeKind Kind);
+
+    public enum SecureStorageChangeKind
+    {
+        Added,
+        Updated,
+        Deleted
+    }
+
+    /// <summary>
+    ///  Minimal, provider-agnostic secure blob store.
+    ///  Accepts opaque, already-encrypted data and returns it unchanged.
+    /// </summary>
+    public interface ISecureStorage : IDisposable
+    {
+        /// <summary>Raised when a blob is added, updated, or deleted by this process.</summary>
+        public event EventHandler<SecureStorageChangedEventArgs>? Changed;
+
+
+        /// <summary>Saves or replaces a blob under the given <paramref name="id"/>.</summary>
+        public ValueTask SaveAsync(string id, ReadOnlyMemory<byte> data, CancellationToken ct = default);
+
+        /// <summary>
+        ///  Attempts to load a blob; returns <c>null</c> when the id is unknown.
+        /// </summary>
+        public ValueTask<ReadOnlyMemory<byte>?> TryLoadAsync(string id, CancellationToken ct = default);
+
+        /// <summary>Deletes the blob if it exists (no-op otherwise).</summary>
+        public ValueTask DeleteAsync(string id, CancellationToken ct = default);
+
+
+        /// <summary>
+        ///  Streams all stored ids; optionally filters by <paramref name="prefix"/>.
+        /// </summary>
+        public IAsyncEnumerable<string> ListIdsAsync(string? prefix = null, CancellationToken ct = default);
+
+
+        /// <summary>
+        ///  Re-encrypts every stored blob with whatever new key/material
+        ///  the implementation chooses.  Callers don’t supply crypto details;
+        ///  they just get told when the job is done.
+        /// </summary>
+        public ValueTask RotateEncryptionAsync(CancellationToken ct = default);
+    }
+}

--- a/PlugHub.UnitTests/Platform/Storage/InsecureStorageTests.cs
+++ b/PlugHub.UnitTests/Platform/Storage/InsecureStorageTests.cs
@@ -1,0 +1,191 @@
+﻿using Microsoft.Extensions.Logging.Abstractions;
+using PlugHub.Platform.Storage;
+using PlugHub.Services;
+using PlugHub.Shared.Interfaces.Platform.Storage;
+
+namespace PlugHub.UnitTests.Platform.Storage
+{
+    internal static class AsyncEnumerableHelpers
+    {
+        public static async Task<List<T>> ToListAsync<T>(this IAsyncEnumerable<T> src)
+        {
+            var list = new List<T>();
+            await foreach (var item in src) list.Add(item);
+            return list;
+        }
+    }
+
+    [TestClass]
+    public sealed partial class InsecureStorageTests
+    {
+        private MSTestHelpers msTestHelpers = null!;
+        private TokenService tokenService = null!;
+        private ConfigService configService = null!;
+        private InsecureStorage storage = null!;
+        private static readonly string[] expected = ["alpha1", "alpha2"];
+
+        [TestInitialize]
+        public void Setup()
+        {
+            this.msTestHelpers = new MSTestHelpers();
+            this.tokenService = new TokenService(new NullLogger<TokenService>());
+            this.configService = new ConfigService(
+                new NullLogger<ConfigService>(),
+                this.tokenService,
+                this.msTestHelpers.TempDirectory,
+                this.msTestHelpers.TempDirectory);
+
+            this.storage = new InsecureStorage(new NullLogger<InsecureStorage>(), this.tokenService, this.configService, this.msTestHelpers.TempDirectory);
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            ((IDisposable)this.storage).Dispose();
+            ((IDisposable)this.configService).Dispose();
+            this.msTestHelpers.Dispose();
+        }
+
+        #region InsecureStorageTests: KeyHandling
+
+        [TestMethod]
+        [TestCategory("KeyHandling")]
+        public async Task SaveThenLoad_RoundTripsBytes()
+        {
+            string id = "roundtrip";
+            byte[] sample = [1, 2, 3, 4, 5];
+
+            await this.storage.SaveAsync(id, sample);
+            byte[]? loaded = (await this.storage.TryLoadAsync(id))?.ToArray();
+
+            CollectionAssert.AreEqual(sample, loaded, "Stored bytes should be retrieved intact.");
+        }
+
+        [TestMethod]
+        [TestCategory("KeyHandling")]
+        public async Task InvalidId_ThrowsArgumentException()
+        {
+            await Assert.ThrowsExceptionAsync<ArgumentException>(
+                async () => await this.storage.SaveAsync("bad/id", new byte[1]));
+        }
+
+        #endregion
+
+        #region InsecureStorageTests: Accessors
+
+        [TestMethod]
+        [TestCategory(nameof(Accessors))]
+        public async Task TryLoadAsync_UnknownId_ReturnsNull()
+        {
+            ReadOnlyMemory<byte>? result = await this.storage.TryLoadAsync("does-not-exist");
+            Assert.IsNull(result, "Unknown blob id should return null.");
+        }
+
+        #endregion
+
+        #region InsecureStorageTests: Mutators
+
+        [TestMethod]
+        [TestCategory("Mutators")]
+        public async Task SaveAsync_NewId_RaisesAddedEvent()
+        {
+            string id = "ev-added";
+            byte[] data = [9];
+
+            SecureStorageChangeKind? observed = null;
+            this.storage.Changed += (_, e)
+                => observed = e.Kind;
+
+            await this.storage.SaveAsync(id, data);
+
+            Assert.AreEqual(SecureStorageChangeKind.Added, observed, "Added event must be raised.");
+        }
+
+        [TestMethod]
+        [TestCategory("Mutators")]
+        public async Task SaveAsync_ExistingId_RaisesUpdatedEvent()
+        {
+            string id = "ev-updated";
+            await this.storage.SaveAsync(id, new byte[] { 1 });
+
+            SecureStorageChangeKind? observed = null;
+            this.storage.Changed += (_, e) => observed = e.Kind;
+
+            await this.storage.SaveAsync(id, new byte[] { 2 });
+
+            Assert.AreEqual(SecureStorageChangeKind.Updated, observed, "Updated event must be raised.");
+        }
+
+        [TestMethod]
+        [TestCategory("Mutators")]
+        public async Task DeleteAsync_RemovesBlobAndRaisesEvent()
+        {
+            string id = "ev-deleted";
+            await this.storage.SaveAsync(id, new byte[] { 3 });
+
+            SecureStorageChangeKind? observed = null;
+            this.storage.Changed += (_, e) => observed = e.Kind;
+
+            await this.storage.DeleteAsync(id);
+
+            Assert.AreEqual(SecureStorageChangeKind.Deleted, observed, "Deleted event must be raised.");
+            Assert.IsNull(await this.storage.TryLoadAsync(id), "Blob should be gone.");
+        }
+
+        #endregion
+
+        #region InsecureStorageTests: Persistence
+
+        [TestMethod]
+        [TestCategory("Persistence")]
+        public async Task Blob_PersistsAcrossInstances()
+        {
+            string id = "persist";
+            byte[] buf = [7, 7, 7];
+            await this.storage.SaveAsync(id, buf);
+
+            // Dispose first instance
+            this.storage.Dispose();
+            this.storage = new InsecureStorage(new NullLogger<InsecureStorage>(), this.tokenService, this.configService, this.msTestHelpers.TempDirectory);
+
+            byte[]? loaded = (await this.storage.TryLoadAsync(id))?.ToArray();
+            CollectionAssert.AreEqual(buf, loaded, "Second instance should read persisted blob.");
+        }
+
+        [TestMethod]
+        [TestCategory("Persistence")]
+        public async Task ListIdsAsync_ReturnsExpectedIdsWithPrefix()
+        {
+            await this.storage.SaveAsync("alpha1", new byte[] { 1 });
+            await this.storage.SaveAsync("alpha2", new byte[] { 2 });
+            await this.storage.SaveAsync("beta1", new byte[] { 3 });
+
+            var ids = await this.storage.ListIdsAsync("alpha").ToListAsync();
+
+            CollectionAssert.AreEquivalent(expected, ids);
+        }
+
+        #endregion
+
+        #region InsecureStorageTests: Disposal
+
+        [TestMethod]
+        [TestCategory("Disposal")]
+        public async Task OperationsAfterDispose_ThrowObjectDisposedException()
+        {
+            this.storage.Dispose();
+
+            await Assert.ThrowsExceptionAsync<ObjectDisposedException>(
+                async () => await this.storage.SaveAsync("x", new byte[1]));
+        }
+
+        #endregion
+
+        #region InsecureStorageTests: Security
+
+        // Currently no crypto logic in the store itself – left as a placeholder
+        // for future tamper-proof or ACL tests.
+
+        #endregion
+    }
+}

--- a/PlugHub/App.axaml.cs
+++ b/PlugHub/App.axaml.cs
@@ -7,8 +7,10 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using PlugHub.Accessors;
+using PlugHub.Platform.Storage;
 using PlugHub.Services;
 using PlugHub.Shared.Interfaces.Accessors;
+using PlugHub.Shared.Interfaces.Platform.Storage;
 using PlugHub.Shared.Interfaces.Services;
 using PlugHub.Shared.Models;
 using PlugHub.ViewModels;
@@ -86,6 +88,8 @@ public partial class App : Application
     {
         services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
         services.AddSingleton<ITokenService, TokenService>();
+        services.AddSingleton<ISecureStorage, InsecureStorage>();
+
         services.AddTransient<IConfigAccessor, ConfigAccessor>();
 
         services.AddSingleton<IConfigService>(provider =>

--- a/PlugHub/Platform/Storage/InsecureStorage.cs
+++ b/PlugHub/Platform/Storage/InsecureStorage.cs
@@ -1,0 +1,226 @@
+﻿using Microsoft.Extensions.Logging;
+using PlugHub.Shared.Interfaces.Models;
+using PlugHub.Shared.Interfaces.Platform.Storage;
+using PlugHub.Shared.Interfaces.Services;
+using PlugHub.Shared.Utility;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PlugHub.Platform.Storage
+{
+    public sealed class InsecureStorageConfig
+    {
+        public string BinaryDirectory { get; init; } =
+            Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                "PlugHub",
+                "SecureStore");
+    }
+
+    public sealed class InsecureStorage : ISecureStorage
+    {
+        public event EventHandler<SecureStorageChangedEventArgs>? Changed;
+
+        private readonly ILogger logger;
+        private readonly ITokenService tokenService;
+        private readonly IConfigService configService;
+        private readonly ITokenSet configTokenSet;
+        private readonly string binaryDirectory;
+        private bool isDisposed;
+        private readonly SemaphoreSlim systemLock = new(1, 1);
+        private readonly ConcurrentDictionary<string, SemaphoreSlim> storageLock = new();
+
+        public InsecureStorage(ILogger<ISecureStorage> logger, ITokenService tokenService, IConfigService configService, string storeRootDirectory = "")
+        {
+            ArgumentNullException.ThrowIfNull(logger);
+            ArgumentNullException.ThrowIfNull(tokenService);
+            ArgumentNullException.ThrowIfNull(configService);
+
+            this.logger = logger;
+            this.configService = configService;
+            this.tokenService = tokenService;
+            this.configTokenSet
+                = this.tokenService
+                    .CreateTokenSet(
+                        this.tokenService.CreateToken(),
+                        this.tokenService.CreateToken(),
+                        this.tokenService.CreateToken());
+
+            this.configService.RegisterConfig(typeof(InsecureStorageConfig), this.configTokenSet);
+
+            if (string.IsNullOrWhiteSpace(storeRootDirectory))
+            {
+                InsecureStorageConfig config =
+                    (InsecureStorageConfig)this.configService.GetConfigInstance(typeof(InsecureStorageConfig), this.configTokenSet);
+
+                this.binaryDirectory = config.BinaryDirectory;
+            }
+            else this.binaryDirectory = storeRootDirectory;
+        }
+
+        public async ValueTask<ReadOnlyMemory<byte>?> TryLoadAsync(string id, CancellationToken ct = default)
+        {
+            ObjectDisposedException.ThrowIf(this.isDisposed, this);
+
+            ValidateId(id);
+
+            string path = this.GetBinaryPath(id);
+            byte[] bytes;
+
+            if (!File.Exists(path))
+            {
+                this.logger.LogDebug("SecureStore: [{Id}] not found – returning null", id);
+                return null;
+            }
+
+            SemaphoreSlim aioLock = this.GetStorageLock(id);
+            await aioLock.WaitAsync(ct).ConfigureAwait(false);
+
+            try
+            {
+                bytes = await File.ReadAllBytesAsync(path, ct);
+
+                this.logger.LogDebug("SecureStore: [{Id}] loaded {Count} bytes", id, bytes.Length);
+            }
+            finally { aioLock.Release(); }
+
+            return bytes;
+        }
+        public async ValueTask SaveAsync(string id, ReadOnlyMemory<byte> data, CancellationToken ct = default)
+        {
+            ObjectDisposedException.ThrowIf(this.isDisposed, this);
+
+            ValidateId(id);
+
+            string path = this.GetBinaryPath(id);
+            bool updating = false;
+
+            SemaphoreSlim aioLock = this.GetStorageLock(id);
+            await aioLock.WaitAsync(ct).ConfigureAwait(false);
+
+            try
+            {
+                updating = File.Exists(path);
+
+                this.logger.LogDebug("SecureStore: [{Id}] saving {Length} bytes (update = {Updating})", id, data.Length, updating);
+
+                await Atomic.WriteAsync(path, data, cancellationToken: ct);
+
+                this.logger.LogInformation("SecureStore: [{Id}] {Action}", id, updating ? "updated" : "added");
+            }
+            finally { aioLock.Release(); }
+
+            Changed?.Invoke(this,
+                new SecureStorageChangedEventArgs(
+                    id,
+                    updating ? SecureStorageChangeKind.Updated : SecureStorageChangeKind.Added));
+        }
+        public async ValueTask DeleteAsync(string id, CancellationToken ct = default)
+        {
+            ObjectDisposedException.ThrowIf(this.isDisposed, this);
+            ValidateId(id);
+
+            string path = this.GetBinaryPath(id);
+
+            SemaphoreSlim aioLock = this.GetStorageLock(id);
+            await aioLock.WaitAsync(ct).ConfigureAwait(false);
+
+            try
+            {
+                if (!File.Exists(path))
+                {
+                    this.logger.LogDebug("SecureStore: [{Id}] delete requested but file missing", id);
+                    return;
+                }
+
+                File.Delete(path);
+
+                this.logger.LogInformation("SecureStore: [{Id}] deleted", id);
+
+                this.storageLock.TryRemove(id, out _);
+            }
+            finally { aioLock.Release(); }
+
+            Changed?.Invoke(this,
+                new SecureStorageChangedEventArgs(id, SecureStorageChangeKind.Deleted));
+        }
+
+
+        public async IAsyncEnumerable<string> ListIdsAsync(string? prefix = null, [EnumeratorCancellation] CancellationToken ct = default)
+        {
+            ObjectDisposedException.ThrowIf(this.isDisposed, this);
+
+            if (!Directory.Exists(this.binaryDirectory))
+                yield break;
+
+            IEnumerable<string> files;
+
+            await this.systemLock.WaitAsync(ct).ConfigureAwait(false);
+
+            this.logger.LogTrace("SecureStore: listing ids (prefix = '{Prefix}')", prefix);
+
+            try
+            {
+                files = Directory
+                    .EnumerateFiles(this.binaryDirectory, "*.bin", SearchOption.TopDirectoryOnly)
+                    .Select(Path.GetFileNameWithoutExtension)
+                    .Where(name => name is not null)
+                    .Select(name => name!);
+            }
+            finally { this.systemLock.Release(); }
+
+            foreach (string id in files)
+            {
+                if (ct.IsCancellationRequested)
+                    yield break;
+
+                if (prefix is null || id.StartsWith(prefix, StringComparison.Ordinal))
+                    yield return id;
+
+                await Task.Yield();
+            }
+        }
+        public ValueTask RotateEncryptionAsync(CancellationToken ct = default)
+            => ValueTask.CompletedTask;
+
+        public void Dispose()
+        {
+            if (this.isDisposed) return;
+
+            this.systemLock.Wait();
+
+            try
+            {
+                this.isDisposed = true;
+                this.configService.UnregisterConfig(typeof(InsecureStorageConfig), this.configTokenSet);
+            }
+            finally { this.systemLock.Release(); }
+
+            GC.SuppressFinalize(this);
+        }
+
+        private SemaphoreSlim GetStorageLock(string id)
+            => this.storageLock.GetOrAdd(id, _ => new SemaphoreSlim(1, 1));
+
+        private static void ValidateId(string id)
+        {
+            if (string.IsNullOrWhiteSpace(id))
+                throw new ArgumentException(
+                    "binary id must be a non-empty string.",
+                    nameof(id));
+
+            if (id.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0)
+                throw new ArgumentException(
+                    "binary id contains invalid path characters.",
+                    nameof(id));
+        }
+        private string GetBinaryPath(string id) =>
+            Path.Combine(this.binaryDirectory, $"{id}.bin");
+    }
+}


### PR DESCRIPTION
## Description

This PR introduces the **SecureStorage** service, establishing a unified, abstracted API for storing sensitive data such as tokens, credentials, and user secrets. The initial implementation uses `InsecureStorage` as a backend, which saves data to a designated location on the file system. While this is suitable for development and testing, it is not intended for production use with sensitive information. The architecture is intentionally pluggable, allowing for seamless integration of platform-specific secure storage backends (e.g., Windows Credential Locker, macOS Keychain, Linux Secret Service) as plugins in the future.

Key points:
- Adds `ISecureStorage` interface and registers it in the DI container.
- Implements `SecureStorage` by delegating to `InsecureStorage`.
- `InsecureStorage` writes to the file system, providing a placeholder for immediate integration and testing.
- Lays the groundwork for future, more secure, platform-native storage plugins.

## Related Issue

- Resolves #28

## Motivation and Context

Many features require secure storage of sensitive information. By centralizing this logic in a dedicated service, the codebase:
- Reduces the risk of security mistakes.
- Makes it easier to maintain and upgrade secure storage practices.
- Prepares for compliance with security best practices.
- Simplifies future upgrades to platform-native secure storage.

## How Has This Been Tested?

- Manual integration testing: Verified that the `SecureStorage` API can be used throughout the app and that data is persisted via the `InsecureStorage` backend.
- Confirmed that data is written to the expected file system location.
- Ran existing unit tests to confirm no regressions in related areas.

## Screenshots

- NA

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Asset change (adds or updates icons, templates, or other assets)
- [ ] Documentation change (adds or updates documentation)
- [ ] Plugin change (adds or updates a plugin)

## Checklist

- [x] I have read the **CONTRIBUTING** document.
- [x] My change requires a change to the core logic.
    - [x] I have linked the project issue above.
- [ ] My change requires a change to the assets.
    - [ ] I have linked the asset issue above.
- [ ] My change requires a change to the documentation.
    - [ ] I have linked the documentation issue above.
- [ ] My change requires a change to a plugin.
    - [ ] I have linked the plugin issue above.