### PR TITLE
Integrates Serilog Logging into Dependency Injection and Centralize Logging Access

### DIFF
--- a/PlugHub.Shared/Interfaces/Accessors/ISecureConfigAccessor.cs
+++ b/PlugHub.Shared/Interfaces/Accessors/ISecureConfigAccessor.cs
@@ -4,14 +4,14 @@ using PlugHub.Shared.Models;
 namespace PlugHub.Shared.Interfaces.Accessors
 {
     /// <summary>Entry-point for encryption-aware configuration access.</summary>
-    public interface ISecureConfigAccessor
+    public interface ISecureConfigAccessor : IConfigAccessor
     {
         public ISecureConfigAccessor Init(IList<Type> configTypes, IEncryptionContext encryptionContext, Token? ownerToken, Token? readToken, Token? writeToken);
 
         /// <summary>Returns a strongly-typed secure accessor for <typeparamref name="TConfig"/>.</summary>
         /// <typeparam name="TConfig">Configuration POCO.</typeparam>
         /// <returns>Secure accessor scoped to <typeparamref name="TConfig"/>.</returns>
-        public ISecureConfigAccessorFor<TConfig> For<TConfig>() where TConfig : class;
+        public new ISecureConfigAccessorFor<TConfig> For<TConfig>() where TConfig : class;
     }
 
     /// <summary>Strongly-typed accessor that transparently encrypts / decrypts secure fields.</summary>

--- a/PlugHub.UnitTests/Accessors/ConfigAccessorTests.cs
+++ b/PlugHub.UnitTests/Accessors/ConfigAccessorTests.cs
@@ -56,7 +56,7 @@ namespace PlugHub.UnitTests.Accessors
         public void For_UnregisteredType_Throws()
         {
             // Arrange & Act
-            IConfigAccessor accessor = new ConfigAccessor(this.configService!)
+            IConfigAccessor accessor = new ConfigAccessor(new NullLogger<IConfigAccessor>(), this.configService!)
                 .Init([typeof(UnitTestAConfig)], this.tokenService!.CreateToken(), Token.Public, Token.Public);
 
             // Assert
@@ -70,7 +70,7 @@ namespace PlugHub.UnitTests.Accessors
             // Arrange
             this.configService!.RegisterConfig(typeof(UnitTestAConfig));
 
-            IConfigAccessor accessor = new ConfigAccessor(this.configService!)
+            IConfigAccessor accessor = new ConfigAccessor(new NullLogger<IConfigAccessor>(), this.configService!)
                 .Init([typeof(UnitTestAConfig)], this.tokenService!.CreateToken(), Token.Public, Token.Public);
 
             // Act
@@ -91,7 +91,7 @@ namespace PlugHub.UnitTests.Accessors
             //Arrange
             this.configService!.RegisterConfig(typeof(UnitTestAConfig));
 
-            IConfigAccessor accessor = new ConfigAccessor(this.configService!)
+            IConfigAccessor accessor = new ConfigAccessor(new NullLogger<IConfigAccessor>(), this.configService!)
                 .Init([typeof(UnitTestAConfig)], this.tokenService!.CreateToken(), Token.Public, Token.Public);
 
             IConfigAccessorFor<UnitTestAConfig> a = accessor.For<UnitTestAConfig>();
@@ -115,7 +115,7 @@ namespace PlugHub.UnitTests.Accessors
             this.configService!.RegisterConfig(typeof(UnitTestAConfig), owner, read, write);
             this.configService.SetSetting(typeof(UnitTestAConfig), nameof(UnitTestAConfig.FieldA), 99, writeToken: write);
 
-            IConfigAccessor accessor = new ConfigAccessor(this.configService!)
+            IConfigAccessor accessor = new ConfigAccessor(new NullLogger<IConfigAccessor>(), this.configService!)
                 .Init([typeof(UnitTestAConfig)], owner, read, write);
 
             IConfigAccessorFor<UnitTestAConfig> aConfig = accessor.For<UnitTestAConfig>();
@@ -140,7 +140,7 @@ namespace PlugHub.UnitTests.Accessors
             this.configService!.RegisterConfig(typeof(UnitTestAConfig), owner, read, write);
 
             // Act
-            IConfigAccessor accessor = new ConfigAccessor(this.configService!)
+            IConfigAccessor accessor = new ConfigAccessor(new NullLogger<IConfigAccessor>(), this.configService!)
                 .Init([typeof(UnitTestAConfig)], this.tokenService!.CreateToken(), read, write);
 
             IConfigAccessorFor<UnitTestAConfig> config = accessor.For<UnitTestAConfig>();
@@ -164,7 +164,7 @@ namespace PlugHub.UnitTests.Accessors
             // Act
             this.configService!.RegisterConfig(typeof(UnitTestAConfig), readToken: read, writeToken: write);
 
-            IConfigAccessor accessor = new ConfigAccessor(this.configService!)
+            IConfigAccessor accessor = new ConfigAccessor(new NullLogger<IConfigAccessor>(), this.configService!)
                 .Init([typeof(UnitTestAConfig)], this.tokenService!.CreateToken(), read, write);
 
             IConfigAccessorFor<UnitTestAConfig> a = accessor.For<UnitTestAConfig>();
@@ -187,7 +187,7 @@ namespace PlugHub.UnitTests.Accessors
             Token write = this.tokenService.CreateToken();
             this.configService!.RegisterConfig(typeof(UnitTestAConfig), owner, read, write);
 
-            IConfigAccessor accessor = new ConfigAccessor(this.configService!)
+            IConfigAccessor accessor = new ConfigAccessor(new NullLogger<IConfigAccessor>(), this.configService!)
                 .Init([typeof(UnitTestAConfig)], owner, read, write);
 
             IConfigAccessorFor<UnitTestAConfig> aConfig = accessor.For<UnitTestAConfig>();
@@ -223,7 +223,7 @@ namespace PlugHub.UnitTests.Accessors
             this.configService!.RegisterConfig(typeof(UnitTestAConfig), owner, read, write);
 
             // Act
-            IConfigAccessor accessor = new ConfigAccessor(this.configService!)
+            IConfigAccessor accessor = new ConfigAccessor(new NullLogger<IConfigAccessor>(), this.configService!)
                 .Init([typeof(UnitTestAConfig)], this.tokenService.CreateToken(), read, Token.Public);
 
             IConfigAccessorFor<UnitTestAConfig> aConfig = accessor.For<UnitTestAConfig>();
@@ -248,7 +248,7 @@ namespace PlugHub.UnitTests.Accessors
             this.configService!.RegisterConfig(typeof(UnitTestAConfig), owner, read, write);
 
             // Act
-            IConfigAccessor accessor = new ConfigAccessor(this.configService!)
+            IConfigAccessor accessor = new ConfigAccessor(new NullLogger<IConfigAccessor>(), this.configService!)
                 .Init([typeof(UnitTestAConfig)], this.tokenService.CreateToken(), Token.Public, write);
 
             IConfigAccessorFor<UnitTestAConfig> config = accessor.For<UnitTestAConfig>();
@@ -271,7 +271,7 @@ namespace PlugHub.UnitTests.Accessors
             this.configService!.RegisterConfig(typeof(UnitTestAConfig), readToken: read, writeToken: write);
 
             // Act
-            IConfigAccessor accessor = new ConfigAccessor(this.configService!)
+            IConfigAccessor accessor = new ConfigAccessor(new NullLogger<IConfigAccessor>(), this.configService!)
                 .Init([typeof(UnitTestAConfig)], this.tokenService!.CreateToken(), read, write);
 
             IConfigAccessorFor<UnitTestAConfig> a = accessor.For<UnitTestAConfig>();
@@ -295,7 +295,7 @@ namespace PlugHub.UnitTests.Accessors
             Token write = this.tokenService.CreateToken();
             this.configService!.RegisterConfig(typeof(UnitTestAConfig), readToken: read, writeToken: write);
 
-            IConfigAccessor accessor = new ConfigAccessor(this.configService!)
+            IConfigAccessor accessor = new ConfigAccessor(new NullLogger<IConfigAccessor>(), this.configService!)
                 .Init([typeof(UnitTestAConfig)], this.tokenService!.CreateToken(), read, write);
 
             IConfigAccessorFor<UnitTestAConfig> a = accessor.For<UnitTestAConfig>();
@@ -327,7 +327,7 @@ namespace PlugHub.UnitTests.Accessors
             Token write = this.tokenService.CreateToken();
             this.configService!.RegisterConfig(typeof(UnitTestAConfig), readToken: read, writeToken: write);
 
-            IConfigAccessor accessor = new ConfigAccessor(this.configService!)
+            IConfigAccessor accessor = new ConfigAccessor(new NullLogger<IConfigAccessor>(), this.configService!)
                 .Init([typeof(UnitTestAConfig)], this.tokenService!.CreateToken(), read, write);
 
             IConfigAccessorFor<UnitTestAConfig> a = accessor.For<UnitTestAConfig>();
@@ -382,7 +382,7 @@ namespace PlugHub.UnitTests.Accessors
             this.configService!.RegisterConfig(typeof(UnitTestAConfig), readToken: read, writeToken: write);
 
             // Act
-            IConfigAccessor accessor = new ConfigAccessor(this.configService!)
+            IConfigAccessor accessor = new ConfigAccessor(new NullLogger<IConfigAccessor>(), this.configService!)
                 .Init([typeof(UnitTestAConfig)], this.tokenService!.CreateToken(), Token.Public, Token.Public);
 
             IConfigAccessorFor<UnitTestAConfig> a = accessor.For<UnitTestAConfig>();
@@ -406,7 +406,7 @@ namespace PlugHub.UnitTests.Accessors
 
             this.configService!.RegisterConfig(typeof(UnitTestAConfig), readToken: read, writeToken: write);
 
-            IConfigAccessor accessor = new ConfigAccessor(this.configService!)
+            IConfigAccessor accessor = new ConfigAccessor(new NullLogger<IConfigAccessor>(), this.configService!)
                 .Init([typeof(UnitTestAConfig)], owner, read, write);
 
             IConfigAccessorFor<UnitTestAConfig> config = accessor.For<UnitTestAConfig>();

--- a/PlugHub.UnitTests/Accessors/SecureConfigAccessorTests.cs
+++ b/PlugHub.UnitTests/Accessors/SecureConfigAccessorTests.cs
@@ -86,7 +86,7 @@ namespace PlugHub.UnitTests.Accessors
         {
             // Arrange
             ISecureConfigAccessorFor<UnitTestSecureAConfig> accessor
-                = new SecureConfigAccessor(this.configService!)
+                = new SecureConfigAccessor(new NullLogger<ISecureConfigAccessor>(), this.configService!)
                     .Init([typeof(UnitTestSecureAConfig)], this.encryptionContext, this.validTokenSet!.Owner, this.validTokenSet!.Read, this.validTokenSet!.Write)
                     .For<UnitTestSecureAConfig>();
 
@@ -99,7 +99,7 @@ namespace PlugHub.UnitTests.Accessors
         public void For_InvalidType_ThrowsTypeAccessException()
         {
             // Arrange
-            ISecureConfigAccessor accessor = new SecureConfigAccessor(this.configService!)
+            ISecureConfigAccessor accessor = new SecureConfigAccessor(new NullLogger<ISecureConfigAccessor>(), this.configService!)
                     .Init([typeof(UnitTestSecureAConfig)], this.encryptionContext, this.validTokenSet!.Owner, this.validTokenSet!.Read, this.validTokenSet!.Write);
 
             // Act & Assert
@@ -115,7 +115,7 @@ namespace PlugHub.UnitTests.Accessors
         public void Set_WithUnknownKey_ThrowsKeyNotFoundException()
         {
             ISecureConfigAccessorFor<UnitTestSecureAConfig> accessor
-                = new SecureConfigAccessor(this.configService!)
+                = new SecureConfigAccessor(new NullLogger<ISecureConfigAccessor>(), this.configService!)
                     .Init([typeof(UnitTestSecureAConfig)], this.encryptionContext)
                     .For<UnitTestSecureAConfig>();
 
@@ -129,7 +129,7 @@ namespace PlugHub.UnitTests.Accessors
         {
             // Arrange
             ISecureConfigAccessorFor<UnitTestSecureAConfig> accessor
-                = new SecureConfigAccessor(this.configService!)
+                = new SecureConfigAccessor(new NullLogger<ISecureConfigAccessor>(), this.configService!)
                     .Init([typeof(UnitTestSecureAConfig)], this.encryptionContext, this.validTokenSet!.Owner, this.validTokenSet!.Read, this.validTokenSet!.Write)
                     .For<UnitTestSecureAConfig>();
 
@@ -159,7 +159,7 @@ namespace PlugHub.UnitTests.Accessors
 
             // Act
             ISecureConfigAccessorFor<UnitTestSecureAConfig> accessor
-                = new SecureConfigAccessor(this.configService!)
+                = new SecureConfigAccessor(new NullLogger<ISecureConfigAccessor>(), this.configService!)
                     .Init([typeof(UnitTestSecureAConfig)], this.encryptionContext, this.tokenService.CreateToken(), badRead, this.validTokenSet!.Write)
                     .For<UnitTestSecureAConfig>();
 
@@ -173,7 +173,7 @@ namespace PlugHub.UnitTests.Accessors
         {
             // Arrange
             ISecureConfigAccessorFor<UnitTestSecureAConfig> accessor
-                = new SecureConfigAccessor(this.configService!)
+                = new SecureConfigAccessor(new NullLogger<ISecureConfigAccessor>(), this.configService!)
                     .Init([typeof(UnitTestSecureAConfig)], this.encryptionContext, this.validTokenSet!.Owner, this.validTokenSet!.Read, this.validTokenSet!.Write)
                     .For<UnitTestSecureAConfig>();
 
@@ -191,7 +191,7 @@ namespace PlugHub.UnitTests.Accessors
         {
             // Arrange
             ISecureConfigAccessorFor<UnitTestSecureAConfig> accessor
-                = new SecureConfigAccessor(this.configService!)
+                = new SecureConfigAccessor(new NullLogger<ISecureConfigAccessor>(), this.configService!)
                     .Init([typeof(UnitTestSecureAConfig)], this.encryptionContext, this.validTokenSet!.Owner, this.validTokenSet!.Read, this.validTokenSet!.Write)
                     .For<UnitTestSecureAConfig>();
 
@@ -216,7 +216,7 @@ namespace PlugHub.UnitTests.Accessors
         {
             // Arrange
             ISecureConfigAccessorFor<UnitTestSecureAConfig> accessor
-                = new SecureConfigAccessor(this.configService!)
+                = new SecureConfigAccessor(new NullLogger<ISecureConfigAccessor>(), this.configService!)
                     .Init([typeof(UnitTestSecureAConfig)], this.encryptionContext, this.validTokenSet!.Owner, this.validTokenSet!.Read, this.validTokenSet!.Write)
                     .For<UnitTestSecureAConfig>();
 
@@ -241,7 +241,7 @@ namespace PlugHub.UnitTests.Accessors
         {
             // Arrange
             ISecureConfigAccessorFor<UnitTestSecureAConfig> accessor
-                = new SecureConfigAccessor(this.configService!)
+                = new SecureConfigAccessor(new NullLogger<ISecureConfigAccessor>(), this.configService!)
                     .Init([typeof(UnitTestSecureAConfig)], this.encryptionContext, this.validTokenSet!.Owner, this.validTokenSet!.Read, this.validTokenSet!.Write)
                     .For<UnitTestSecureAConfig>();
 
@@ -262,7 +262,7 @@ namespace PlugHub.UnitTests.Accessors
         {
             // Arrange
             ISecureConfigAccessorFor<UnitTestSecureAConfig> accessor
-                = new SecureConfigAccessor(this.configService!)
+                = new SecureConfigAccessor(new NullLogger<ISecureConfigAccessor>(), this.configService!)
                     .Init([typeof(UnitTestSecureAConfig)], this.encryptionContext, this.validTokenSet!.Owner, this.validTokenSet!.Read, this.validTokenSet!.Write)
                     .For<UnitTestSecureAConfig>();
 
@@ -286,7 +286,7 @@ namespace PlugHub.UnitTests.Accessors
         {
             // Arrange
             ISecureConfigAccessorFor<UnitTestSecureAConfig> accessor
-                = new SecureConfigAccessor(this.configService!)
+                = new SecureConfigAccessor(new NullLogger<ISecureConfigAccessor>(), this.configService!)
                     .Init([typeof(UnitTestSecureAConfig)], this.encryptionContext, this.validTokenSet!.Owner, this.validTokenSet!.Read, this.validTokenSet!.Write)
                     .For<UnitTestSecureAConfig>();
 
@@ -308,7 +308,7 @@ namespace PlugHub.UnitTests.Accessors
         {
             // Arrange
             ISecureConfigAccessorFor<UnitTestSecureAConfig> accessor
-                = new SecureConfigAccessor(this.configService!)
+                = new SecureConfigAccessor(new NullLogger<ISecureConfigAccessor>(), this.configService!)
                     .Init([typeof(UnitTestSecureAConfig)], this.encryptionContext, this.validTokenSet!.Owner, this.validTokenSet!.Read, this.validTokenSet!.Write)
                     .For<UnitTestSecureAConfig>();
 

--- a/PlugHub/Accessors/ConfigAccessor.cs
+++ b/PlugHub/Accessors/ConfigAccessor.cs
@@ -1,4 +1,5 @@
-﻿using PlugHub.Shared.Interfaces.Accessors;
+﻿using Microsoft.Extensions.Logging;
+using PlugHub.Shared.Interfaces.Accessors;
 using PlugHub.Shared.Interfaces.Models;
 using PlugHub.Shared.Interfaces.Services;
 using PlugHub.Shared.Models;
@@ -10,8 +11,9 @@ using System.Threading.Tasks;
 
 namespace PlugHub.Accessors
 {
-    public class ConfigAccessor(IConfigService configService) : IConfigAccessor
+    public class ConfigAccessor(ILogger<IConfigAccessor> logger, IConfigService configService) : IConfigAccessor
     {
+        protected readonly ILogger<IConfigAccessor> Logger = logger;
         protected readonly IConfigService ConfigService = configService;
         protected readonly List<Type> ConfigTypes = [];
 

--- a/PlugHub/Accessors/SecureConfigAccessor.cs
+++ b/PlugHub/Accessors/SecureConfigAccessor.cs
@@ -1,4 +1,5 @@
-﻿using PlugHub.Shared.Interfaces.Accessors;
+﻿using Microsoft.Extensions.Logging;
+using PlugHub.Shared.Interfaces.Accessors;
 using PlugHub.Shared.Interfaces.Models;
 using PlugHub.Shared.Interfaces.Services;
 using PlugHub.Shared.Models;
@@ -12,8 +13,10 @@ using System.Threading.Tasks;
 
 namespace PlugHub.Accessors
 {
-    public class SecureConfigAccessor(IConfigService configService) : ConfigAccessor(configService), ISecureConfigAccessor
+    public class SecureConfigAccessor(ILogger<ISecureConfigAccessor> logger, IConfigService configService) 
+        : ConfigAccessor((ILogger<IConfigAccessor>)logger, configService), ISecureConfigAccessor
     {
+        protected new readonly ILogger<ISecureConfigAccessor> Logger = logger;
         public IEncryptionContext? EncryptionContext;
 
         public ISecureConfigAccessor Init(IList<Type> configTypes, IEncryptionContext encryptionContext, Token? ownerToken = null, Token? readToken = null, Token? writeToken = null)

--- a/PlugHub/Services/SecureConfigService.cs
+++ b/PlugHub/Services/SecureConfigService.cs
@@ -33,7 +33,7 @@ namespace PlugHub.Services
             w.WriteStringValue(v.EncryptedBase64);
     }
 
-    public class SecureConfigService(ILogger<IConfigService> logger, ITokenService tokenService, string configRootDirectory, string configUserDirectory)
+    public class SecureConfigService(ILogger<ISecureConfigService> logger, ITokenService tokenService, string configRootDirectory, string configUserDirectory)
         : ConfigService(logger, tokenService, configRootDirectory, configUserDirectory), ISecureConfigService, IDisposable
     {
         #region SecureConfigService: Registration


### PR DESCRIPTION
## Description

This PR integrates **Serilog** as the primary logging provider within the PlugHub dependency injection (DI) system. Logging is now fully centralized and available from the earliest point in the application lifecycle, including during plugin discovery and registration. The log file path and directory are explicitly configurable, and all core services access logging through DI, ensuring robust diagnostics and maintainability.

**Key changes:**
- Configured Serilog in `App.axaml.cs` during DI setup, with file sink, minimum log level, and configurable log path.
- Registered `ILogger` via DI for all core services.
- Removed direct instantiation of loggers and replaced all `NullLogger<>` usage in production code with DI-provided loggers.
- Added runtime log file location reconfiguration support.
- Updated `AppConfig` to expose logging settings (`LoggingDirectory`, `LoggingFileName`, `LoggingRolloverInterval`).

## Related Issue

- Resolves #8

## Motivation and Context

- **Why:**  
  - Ensures consistent, maintainable, and enterprise-grade logging across the application.
  - Enables robust diagnostics and traceability from the earliest startup phase.
  - Adheres to PlugHub’s architecture and best practices for centralized logging.

- **What problem does it solve:**  
  - Eliminates fragmented or ad-hoc logging.
  - Makes log file location and rollover configurable.
  - Guarantees logging is available during all critical phases, including plugin loading.

## How Has This Been Tested?

- Manual verification that logs are written to the configured directory and file.
- Confirmed logging is available during application startup, service registration, and plugin loading.
- Ran all unit tests to ensure no regressions; unit tests use `NullLogger<>` for isolation.
- Tested runtime reconfiguration of log file location and verified correct log output.

## Screenshots

_N/A_

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Asset change (adds or updates icons, templates, or other assets)
- [ ] Documentation change (adds or updates documentation)
- [ ] Plugin change (adds or updates a plugin)

## Checklist

- [x] I have read the **CONTRIBUTING** document.
- [x] My change requires a change to the core logic.
    - [x] I have linked the project issue above.
- [ ] My change requires a change to the assets.
    - [ ] I have linked the asset issue above.
- [ ] My change requires a change to the documentation.
    - [ ] I have linked the documentation issue above.
- [ ] My change requires a change to a plugin.
    - [ ] I have linked the plugin issue above.