### PR TITLE
Fixes Test Suites Writing Keys to Actual Keystore

### DIFF
--- a/PlugHub.UnitTests/Accessors/SecureConfigAccessorTests.cs
+++ b/PlugHub.UnitTests/Accessors/SecureConfigAccessorTests.cs
@@ -53,7 +53,7 @@ namespace PlugHub.UnitTests.Accessors
                 this.msTestHelpers.TempDirectory,
                 this.msTestHelpers.TempDirectory);
 
-            this.secureStorage = new InsecureStorage(new NullLogger<InsecureStorage>(), this.tokenService, this.configService);
+            this.secureStorage = new InsecureStorage(new NullLogger<InsecureStorage>(), this.tokenService, this.configService, this.msTestHelpers.TempDirectory);
             this.encryptionService = new EncryptionService(new NullLogger<EncryptionService>(), this.secureStorage);
             this.encryptionContext = this.encryptionService.GetEncryptionContext<SecureConfigAccessorTests>(
                 new("EFFFFFFF-FFFF-EEEE-FFFF-FFFFFFFFFFFE"));

--- a/PlugHub.UnitTests/Model/SecureValueTests.cs
+++ b/PlugHub.UnitTests/Model/SecureValueTests.cs
@@ -9,7 +9,7 @@ namespace PlugHub.UnitTests.Model
     [TestClass]
     public sealed class SecureValueTests : IDisposable
     {
-        private readonly MSTestHelpers helpers = new();
+        private readonly MSTestHelpers msTestHelpers = new();
         private EncryptionService? encryptionService;
         private IEncryptionContext? encryptionContext;
 
@@ -20,9 +20,9 @@ namespace PlugHub.UnitTests.Model
             TokenService tokenService = new(new NullLogger<TokenService>());
             ConfigService configService = new(new NullLogger<ConfigService>(),
                 tokenService,
-                this.helpers.TempDirectory,
-                this.helpers.TempDirectory);
-            InsecureStorage storage = new(new NullLogger<InsecureStorage>(), tokenService, configService);
+                this.msTestHelpers.TempDirectory,
+                this.msTestHelpers.TempDirectory);
+            InsecureStorage storage = new(new NullLogger<InsecureStorage>(), tokenService, configService, this.msTestHelpers.TempDirectory);
 
             this.encryptionService = new EncryptionService(new NullLogger<EncryptionService>(), storage);
             this.encryptionContext = this.encryptionService.GetEncryptionContext<SecureValueTests>(Guid.NewGuid());
@@ -32,7 +32,7 @@ namespace PlugHub.UnitTests.Model
         public void Dispose()
         {
             (this.encryptionService as IDisposable)?.Dispose();
-            this.helpers.Dispose();
+            this.msTestHelpers.Dispose();
         }
 
 

--- a/PlugHub.UnitTests/Services/EncryptionServiceTests.cs
+++ b/PlugHub.UnitTests/Services/EncryptionServiceTests.cs
@@ -369,7 +369,7 @@ namespace PlugHub.UnitTests.Services
                 tokenService, this.msTestHelpers.
                 TempDirectory,
                 this.msTestHelpers.TempDirectory);
-            var storage = new InsecureStorage(new NullLogger<InsecureStorage>(), tokenService, configService);
+            var storage = new InsecureStorage(new NullLogger<InsecureStorage>(), tokenService, configService, this.msTestHelpers.TempDirectory);
 
             this.encryptionService = new EncryptionService(new NullLogger<EncryptionService>(), storage);
             IEncryptionContext encryptionContext =


### PR DESCRIPTION
## Description

This PR updates the test suites for secure storage to ensure that all instances of `InsecureStorage` in unit tests are now explicitly pointed at a temporary directory (`msTestHelpers.TempDirectory`). Previously, some tests were inadvertently writing keys and secrets to the actual keystore, which could pollute the user's environment and cause test flakiness or side effects between runs. With this change, all secure storage operations in tests are fully isolated and use a temp directory, ensuring no test artifacts leak into the real keystore.

## Related Issue

- Fixes #35

## Motivation and Context

- **Why:** Tests should never write to the real keystore or persistent user data locations. This change ensures test isolation, prevents pollution of the user's keystore, and eliminates side effects between test runs.
- **Problem Solved:** Prevents test artifacts from being left in the real keystore, which could cause unpredictable behavior or failures in both tests and production environments.

## How Has This Been Tested?

- Ran all affected test suites (`SecureConfigAccessorTests`, `SecureValueTests`, `EncryptionServiceTests`) before and after the change.
- Verified that no new files or keys are created in the actual keystore location.
- Confirmed that all test artifacts are now written only to the temp directory provided by `msTestHelpers.TempDirectory`.
- All tests pass and are now fully isolated.

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Asset change (adds or updates icons, templates, or other assets)
- [ ] Documentation change (adds or updates documentation)
- [ ] Plugin change (adds or updates a plugin)

## Checklist

- [x] I have read the **CONTRIBUTING** document.
- [x] My change requires a change to the core logic.
    - [x] I have linked the project issue above.
- [ ] My change requires a change to the assets.
    - [ ] I have linked the asset issue above.
- [ ] My change requires a change to the documentation.
    - [ ] I have linked the documentation issue above.
- [ ] My change requires a change to a plugin.
    - [ ] I have linked the plugin issue above.