### PR TITLE
Implemented Graceful Shutdown and Disposal of Services and Logging

### DIFF
--- a/PlugHub/App.axaml.cs
+++ b/PlugHub/App.axaml.cs
@@ -75,6 +75,8 @@ public partial class App : Application
             // More info: https://docs.avaloniaui.net/docs/guides/development-guides/data-validation#manage-validationplugins
             DisableAvaloniaDataAnnotationValidation();
 
+            desktop.ShutdownRequested += this.OnShutdownRequested;
+
             desktop.MainWindow = new MainWindow
             {
                 DataContext = new MainViewModel()
@@ -89,6 +91,14 @@ public partial class App : Application
         }
 
         base.OnFrameworkInitializationCompleted();
+    }
+    private void OnShutdownRequested(object? sender, ShutdownRequestedEventArgs e)
+    {
+        // Dispose DI container and all services
+        (this.serviceProvider as IDisposable)?.Dispose();
+
+        // Flush and dispose Serilog
+        Serilog.Log.CloseAndFlush();
     }
 
     private static IServiceProvider BuildServices()


### PR DESCRIPTION
## Description

This PR adds a robust shutdown sequence to the PlugHub Desktop application, ensuring that all registered services and the centralized logging infrastructure are properly disposed of when the application exits. Specifically:

- Hooks into the `ShutdownRequested` event of `IClassicDesktopStyleApplicationLifetime` in `App.axaml.cs`.
- Disposes the DI container (and all `IDisposable` singleton/scoped services) by casting `serviceProvider` to `IDisposable` and calling `Dispose()`.
- Flushes and closes the Serilog logger with `Serilog.Log.CloseAndFlush()` to guarantee all logs are written before exit.

No plugin disposal logic is included at this time, as plugins are not yet implemented. When plugins are added and registered with DI, they will be disposed automatically by the container.

## Related Issue

- Resolves #9

## Motivation and Context

Properly disposing of services and logging resources during application shutdown is essential to prevent resource leaks, ensure data integrity, and maintain a clean, maintainable codebase. This change aligns with best practices for .NET desktop applications using dependency injection and structured logging.

## How Has This Been Tested?

- Manual testing: Launched the application, interacted with the main window, and then closed the app to trigger the shutdown sequence.
- Verified via debugger and log output that:
  - The `ShutdownRequested` handler is invoked.
  - The DI container is disposed without errors.
  - Serilog logs are flushed and the logger is closed.
- No resource leaks or unflushed logs observed on repeated runs.

## Screenshots (if appropriate):

_N/A (no UI changes)_

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Asset change (adds or updates icons, templates, or other assets)
- [ ] Documentation change (adds or updates documentation)
- [ ] Plugin change (adds or updates a plugin)

## Checklist

- [x] I have read the **CONTRIBUTING** document.
- [x] My change requires a change to the core logic.
    - [x] I have linked the project issue above.
- [ ] My change requires a change to the assets.
    - [ ] I have linked the asset issue above.
- [ ] My change requires a change to the documentation.
    - [ ] I have linked the documentation issue above.
- [ ] My change requires a change to a plugin.
    - [ ] I have linked the plugin issue above.