### PR TITLE
Added FileConfigService non-Async Object Save overrride

### DIFF
--- a/PlugHub.UnitTests/Services/Configuration/FileConfigServiceTests.cs
+++ b/PlugHub.UnitTests/Services/Configuration/FileConfigServiceTests.cs
@@ -660,13 +660,13 @@ namespace PlugHub.UnitTests.Services.Configuration
 
             this.configService!.RegisterConfig(typeof(UnitTestAConfig), this.fileParams);
 
-            var writers = Enumerable.Range(0, writerTasks).Select(_ => Task.Run(() =>
+            IEnumerable<Task> writers = Enumerable.Range(0, writerTasks).Select(_ => Task.Run(() =>
             {
                 for (int i = 0; i < iterations; i++)
                     this.configService!.SetSetting(typeof(UnitTestAConfig), nameof(UnitTestAConfig.FieldA), i, this.tokenSet);
             }));
 
-            var readers = Enumerable.Range(0, readerTasks).Select(_ => Task.Run(() =>
+            IEnumerable<Task> readers = Enumerable.Range(0, readerTasks).Select(_ => Task.Run(() =>
             {
                 for (int i = 0; i < iterations; i++)
                     _ = this.configService!.GetSetting<int>(typeof(UnitTestAConfig), nameof(UnitTestAConfig.FieldA), this.tokenSet);

--- a/PlugHub/Accessors/Configuration/SecureFileConfigAccessor.cs
+++ b/PlugHub/Accessors/Configuration/SecureFileConfigAccessor.cs
@@ -246,7 +246,7 @@ namespace PlugHub.Accessors.Configuration
                        t => t.GetProperties(BindingFlags.Public | BindingFlags.Instance));
             protected static PropertyInfo? GetCachedProperty(string propertyName)
             {
-                var props = PropertyCache.GetOrAdd(
+                PropertyInfo[] props = PropertyCache.GetOrAdd(
                     typeof(TConfig),
                     t => t.GetProperties(BindingFlags.Public | BindingFlags.Instance));
 


### PR DESCRIPTION
## Description

This PR implements the missing non-async `SaveConfigInstance` method in `FileConfigService` using a fire-and-forget pattern. This method wraps the existing `SaveConfigInstanceAsync` method and mirrors the implementation style used in `SaveDefaultConfigFileContents`. The change ensures consistent behavior across sync and async save operations and prevents `NotImplementedException` from being thrown when the sync method is called.

## Related Issue

Fixes #43

## Motivation and Context

Previously, the base `ConfigServiceBase` defined a non-async `SaveConfigInstance` method that threw a `NotImplementedException`, and `FileConfigService` did not override it. While the async save method was implemented and tested, the sync method was not, leading to runtime exceptions when called.

This change resolves that issue by implementing a fire-and-forget wrapper that:
- Retrieves the config and validates access.
- Calls the async save method in a background task.
- Triggers the appropriate completion or error callbacks.

This aligns with the existing pattern used for saving default file contents and ensures consistent behavior across the API surface.

## How Has This Been Tested?
- Fire-and-forget save operations are not directly covered by automated tests.  But I visually inspected that the other fire and forget methods were present.

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Asset change (adds or updates icons, templates, or other assets)
- [ ] Documentation change (adds or updates documentation)
- [ ] Plugin change (adds or updates a plugin)

## Checklist:

- [x] I have read the **CONTRIBUTING** document.
- [x] My change requires a change to the core logic.
    - [x] I have linked the project issue above.
- [ ] My change requires a change to the assets.
    - [ ] I have linked the asset issue above.
- [ ] My change requires a change to the documentation.
    - [ ] I have linked the documentation issue above.
- [ ] My change requires a change to a plugin.
    - [ ] I have linked the plugin issue above.

Let me know if you'd like a shorter version or if you're using a specific PR format (e.g., Conventional Commits or Semantic PRs).