### PR TITLE
Added Configuration Accessors Authorization Tokens in ConfigService

### DIFF
--- a/PlugHub/Services/Configuration/ConfigService.cs
+++ b/PlugHub/Services/Configuration/ConfigService.cs
@@ -141,7 +141,7 @@ namespace PlugHub.Services.Configuration
         {
             this.RegisterConfig(typeof(TConfig), configParams);
 
-            accessor = this.GetAccessor<TConfig>();
+            accessor = this.GetAccessor<TConfig>(configParams.Owner, configParams.Read, configParams.Write);
         }
         public void RegisterConfigs(IEnumerable<Type> configTypes, IConfigServiceParams configParams)
         {
@@ -164,7 +164,7 @@ namespace PlugHub.Services.Configuration
 
             IConfigServiceProvider provider = this.GetProviderForParamsType(paramType);
 
-            accessor = this.GetAccessor(provider.RequiredAccessorInterface, configTypes);
+            accessor = this.GetAccessor(provider.RequiredAccessorInterface, configTypes, configParams.Owner, configParams.Read, configParams.Write);
         }
 
         public void UnregisterConfig(Type configType, Token? token = null)


### PR DESCRIPTION
## Description

Previously, the `GetAccessor` methods in `ConfigService` were called without the required authorization tokens (`Owner`, `Read`, `Write`) from `configParams`. This PR updates those calls to explicitly pass these tokens, ensuring configuration accessors are always created with the correct security context.

## Related Issue

- Fixes #45 

## Motivation and Context

Configuration accessors must respect the security context provided by the caller. Missing tokens caused accessors to operate with incorrect or default permissions, potentially leading to access failures or security issues.

## How Has This Been Tested?

- Manually verified that configuration accessors now receive and use the correct tokens.
- Ensured existing configuration read/write operations continue to work as expected.
- No new automated tests were added, but existing test coverage for config access was validated.

## Screenshots (if appropriate):

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Asset change (adds or updates icons, templates, or other assets)
- [ ] Documentation change (adds or updates documentation)
- [ ] Plugin change (adds or updates a plugin)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My change requires a change to the core logic.
    - [x] I have linked the project issue above.
- [ ] My change requires a change to the assets.
    - [ ] I have linked the asset issue above.
- [ ] My change requires a change to the documentation.
    - [ ] I have linked the documentation issue above.
- [ ] My change requires a change to a plugin.
    - [ ] I have linked the plugin issue above.
