### PR TITLE
Configuration Parameter Types Moved to PlugHub.Shared

### DIFF
--- a/PlugHub.Shared/Models/Configuration/FileConfigServiceParams.cs
+++ b/PlugHub.Shared/Models/Configuration/FileConfigServiceParams.cs
@@ -1,0 +1,11 @@
+﻿using PlugHub.Shared.Interfaces.Services;
+using PlugHub.Shared.Models;
+using System.Text.Json;
+
+namespace PlugHub.Shared.Models.Configuration
+{
+    public record FileConfigServiceParams(string? ConfigUriOverride = null, Token? Owner = null, Token? Read = null, Token? Write = null, JsonSerializerOptions? JsonSerializerOptions = null, bool ReloadOnChange = false)
+        : IConfigServiceParams
+    {
+    }
+}

--- a/PlugHub.Shared/Models/Configuration/SecureFileConfigServiceParams.cs
+++ b/PlugHub.Shared/Models/Configuration/SecureFileConfigServiceParams.cs
@@ -1,0 +1,9 @@
+﻿using PlugHub.Shared.Interfaces.Models;
+using PlugHub.Shared.Models;
+using System.Text.Json;
+
+namespace PlugHub.Shared.Models.Configuration
+{
+    public record SecureFileConfigServiceParams(IEncryptionContext? EncryptionContext = null, string? ConfigUriOverride = null, Token? Owner = null, Token? Read = null, Token? Write = null, JsonSerializerOptions? JsonSerializerOptions = null, bool ReloadOnChange = false)
+        : FileConfigServiceParams(ConfigUriOverride, Owner, Read, Write, JsonSerializerOptions, ReloadOnChange);
+}

--- a/PlugHub.Shared/Models/Configuration/SecureUserFileConfigServiceParams.cs
+++ b/PlugHub.Shared/Models/Configuration/SecureUserFileConfigServiceParams.cs
@@ -1,0 +1,9 @@
+﻿using PlugHub.Shared.Interfaces.Models;
+using PlugHub.Shared.Models;
+using System.Text.Json;
+
+namespace PlugHub.Shared.Models.Configuration
+{
+    public record SecureUserFileConfigServiceParams(IEncryptionContext? EncryptionContext = null, string? UserConfigUriOverride = null, string? ConfigUriOverride = null, Token? Owner = null, Token? Read = null, Token? Write = null, JsonSerializerOptions? JsonSerializerOptions = null, bool ReloadOnChange = false)
+        : UserConfigServiceParams(UserConfigUriOverride, ConfigUriOverride, Owner, Read, Write, JsonSerializerOptions, ReloadOnChange);
+}

--- a/PlugHub.Shared/Models/Configuration/UserConfigServiceParams.cs
+++ b/PlugHub.Shared/Models/Configuration/UserConfigServiceParams.cs
@@ -1,0 +1,9 @@
+﻿using PlugHub.Shared.Interfaces.Services;
+using PlugHub.Shared.Models;
+using System.Text.Json;
+
+namespace PlugHub.Shared.Models.Configuration
+{
+    public record UserConfigServiceParams(string? UserConfigUriOverride = null, string? ConfigUriOverride = null, Token? Owner = null, Token? Read = null, Token? Write = null, JsonSerializerOptions? JsonSerializerOptions = null, bool ReloadOnChange = false)
+        : FileConfigServiceParams(ConfigUriOverride, Owner, Read, Write, JsonSerializerOptions, ReloadOnChange), IConfigServiceParams;
+}

--- a/PlugHub.UnitTests/Accessors/Configuration/FileConfigAccessorTests.cs
+++ b/PlugHub.UnitTests/Accessors/Configuration/FileConfigAccessorTests.cs
@@ -9,6 +9,7 @@ using PlugHub.Shared.Interfaces.Models;
 using PlugHub.Shared.Interfaces.Platform.Storage;
 using PlugHub.Shared.Interfaces.Services;
 using PlugHub.Shared.Models;
+using PlugHub.Shared.Models.Configuration;
 
 namespace PlugHub.UnitTests.Accessors.Configuration
 {

--- a/PlugHub.UnitTests/Accessors/Configuration/SecureFileConfigAccessorTests.cs
+++ b/PlugHub.UnitTests/Accessors/Configuration/SecureFileConfigAccessorTests.cs
@@ -9,6 +9,7 @@ using PlugHub.Shared.Interfaces.Models;
 using PlugHub.Shared.Interfaces.Platform.Storage;
 using PlugHub.Shared.Interfaces.Services;
 using PlugHub.Shared.Models;
+using PlugHub.Shared.Models.Configuration;
 
 namespace PlugHub.UnitTests.Accessors.Configuration
 {

--- a/PlugHub.UnitTests/Accessors/Configuration/SecureUserFileConfigAccessorTests.cs
+++ b/PlugHub.UnitTests/Accessors/Configuration/SecureUserFileConfigAccessorTests.cs
@@ -9,6 +9,7 @@ using PlugHub.Shared.Interfaces.Models;
 using PlugHub.Shared.Interfaces.Platform.Storage;
 using PlugHub.Shared.Interfaces.Services;
 using PlugHub.Shared.Models;
+using PlugHub.Shared.Models.Configuration;
 
 namespace PlugHub.UnitTests.Accessors.Configuration
 {

--- a/PlugHub.UnitTests/Services/Configuration/FileConfigServiceTests.cs
+++ b/PlugHub.UnitTests/Services/Configuration/FileConfigServiceTests.cs
@@ -6,6 +6,7 @@ using PlugHub.Services.Configuration;
 using PlugHub.Shared.Interfaces.Models;
 using PlugHub.Shared.Interfaces.Services;
 using PlugHub.Shared.Models;
+using PlugHub.Shared.Models.Configuration;
 
 namespace PlugHub.UnitTests.Services.Configuration
 {

--- a/PlugHub.UnitTests/Services/Configuration/UserConfigServiceTests.cs
+++ b/PlugHub.UnitTests/Services/Configuration/UserConfigServiceTests.cs
@@ -6,6 +6,7 @@ using PlugHub.Shared.Extensions;
 using PlugHub.Shared.Interfaces.Models;
 using PlugHub.Shared.Interfaces.Services;
 using PlugHub.Shared.Models;
+using PlugHub.Shared.Models.Configuration;
 
 namespace PlugHub.UnitTests.Services.Configuration
 {

--- a/PlugHub/App.axaml.cs
+++ b/PlugHub/App.axaml.cs
@@ -14,6 +14,7 @@ using PlugHub.Shared.Interfaces.Models;
 using PlugHub.Shared.Interfaces.Platform.Storage;
 using PlugHub.Shared.Interfaces.Services;
 using PlugHub.Shared.Models;
+using PlugHub.Shared.Models.Configuration;
 using PlugHub.ViewModels;
 using PlugHub.Views;
 using Serilog;

--- a/PlugHub/Services/Configuration/FileConfigService.cs
+++ b/PlugHub/Services/Configuration/FileConfigService.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Logging;
 using PlugHub.Shared.Interfaces.Accessors;
 using PlugHub.Shared.Interfaces.Services;
 using PlugHub.Shared.Models;
+using PlugHub.Shared.Models.Configuration;
 using PlugHub.Shared.Utility;
 using System;
 using System.Collections.Generic;
@@ -15,10 +16,6 @@ using System.Threading.Tasks;
 
 namespace PlugHub.Services.Configuration
 {
-    public record FileConfigServiceParams(string? ConfigUriOverride = null, Token? Owner = null, Token? Read = null, Token? Write = null, JsonSerializerOptions? JsonSerializerOptions = null, bool ReloadOnChange = false)
-        : IConfigServiceParams
-    {
-    }
     public class FileConfigServiceConfig(IConfigService configService, string configPath, IConfiguration config, Dictionary<string, object?> values, JsonSerializerOptions? jsonOptions, Token ownerToken, Token readToken, Token writeToken, bool reloadOnChanged)
     {
         public IConfigService ConfigService { get; init; } = configService;

--- a/PlugHub/Services/Configuration/SecureFileConfigService.cs
+++ b/PlugHub/Services/Configuration/SecureFileConfigService.cs
@@ -5,6 +5,7 @@ using PlugHub.Shared.Interfaces.Accessors;
 using PlugHub.Shared.Interfaces.Models;
 using PlugHub.Shared.Interfaces.Services;
 using PlugHub.Shared.Models;
+using PlugHub.Shared.Models.Configuration;
 using PlugHub.Shared.Utility;
 using System;
 using System.Collections.Generic;
@@ -17,8 +18,6 @@ using System.Text.Json.Serialization;
 
 namespace PlugHub.Services.Configuration
 {
-    public record SecureFileConfigServiceParams(IEncryptionContext? EncryptionContext = null, string? ConfigUriOverride = null, Token? Owner = null, Token? Read = null, Token? Write = null, JsonSerializerOptions? JsonSerializerOptions = null, bool ReloadOnChange = false)
-        : FileConfigServiceParams(ConfigUriOverride, Owner, Read, Write, JsonSerializerOptions, ReloadOnChange);
     public class SecureFileConfigServiceConfig(IEncryptionContext encryptionContext, IConfigService configService, string configPath, IConfiguration config, Dictionary<string, object?> values, JsonSerializerOptions? jsonOptions, Token ownerToken, Token readToken, Token writeToken, bool reloadOnChange)
         : FileConfigServiceConfig(configService, configPath, config, values, jsonOptions, ownerToken, readToken, writeToken, reloadOnChange)
     {

--- a/PlugHub/Services/Configuration/SecureUserFileConfigService.cs
+++ b/PlugHub/Services/Configuration/SecureUserFileConfigService.cs
@@ -5,6 +5,7 @@ using PlugHub.Shared.Interfaces.Accessors;
 using PlugHub.Shared.Interfaces.Models;
 using PlugHub.Shared.Interfaces.Services;
 using PlugHub.Shared.Models;
+using PlugHub.Shared.Models.Configuration;
 using PlugHub.Shared.Utility;
 using System;
 using System.Collections.Generic;
@@ -16,8 +17,6 @@ using System.Text.Json;
 
 namespace PlugHub.Services.Configuration
 {
-    public record SecureUserFileConfigServiceParams(IEncryptionContext? EncryptionContext = null, string? UserConfigUriOverride = null, string? ConfigUriOverride = null, Token? Owner = null, Token? Read = null, Token? Write = null, JsonSerializerOptions? JsonSerializerOptions = null, bool ReloadOnChange = false)
-        : UserConfigServiceParams(UserConfigUriOverride, ConfigUriOverride, Owner, Read, Write, JsonSerializerOptions, ReloadOnChange);
     public class SecureUserConfigServiceConfig(IEncryptionContext encryptionContext, IConfigService configService, string configPath, string userConfigPath, IConfiguration config, IConfiguration userConfig, Dictionary<string, object?> values, JsonSerializerOptions? jsonOptions, Token ownerToken, Token readToken, Token writeToken, bool reloadOnChange)
         : UserConfigServiceConfig(configService, configPath, userConfigPath, config, userConfig, values, jsonOptions, ownerToken, readToken, writeToken, reloadOnChange)
     {

--- a/PlugHub/Services/Configuration/UserFileConfigService.cs
+++ b/PlugHub/Services/Configuration/UserFileConfigService.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Logging;
 using PlugHub.Shared.Interfaces.Accessors;
 using PlugHub.Shared.Interfaces.Services;
 using PlugHub.Shared.Models;
+using PlugHub.Shared.Models.Configuration;
 using PlugHub.Shared.Utility;
 using System;
 using System.Collections.Generic;
@@ -15,8 +16,6 @@ using System.Threading.Tasks;
 
 namespace PlugHub.Services.Configuration
 {
-    public record UserConfigServiceParams(string? UserConfigUriOverride = null, string? ConfigUriOverride = null, Token? Owner = null, Token? Read = null, Token? Write = null, JsonSerializerOptions? JsonSerializerOptions = null, bool ReloadOnChange = false)
-        : FileConfigServiceParams(ConfigUriOverride, Owner, Read, Write, JsonSerializerOptions, ReloadOnChange), IConfigServiceParams;
     public class UserConfigServiceConfig(IConfigService configService, string configPath, string userConfigPath, IConfiguration config, IConfiguration userConfig, Dictionary<string, object?> values, JsonSerializerOptions? jsonOptions, Token ownerToken, Token readToken, Token writeToken, bool reloadOnChange)
         : FileConfigServiceConfig(configService, configPath, config, values, jsonOptions, ownerToken, readToken, writeToken, reloadOnChange)
     {


### PR DESCRIPTION
## Description

This pull request migrates all configuration parameter record types—`FileConfigServiceParams`, `UserConfigServiceParams`, `SecureFileConfigServiceParams`, and `SecureUserFileConfigServiceParams`—from the core and service layers into `PlugHub.Shared.Models.Configuration`. Now, these types are explicitly accessible to plugins and all external consumers without any dependency on implementation or host assemblies. All references and usages throughout the solution (including unit tests and service implementations) have been updated accordingly, removing internal duplication and aligning to a single source of truth.

## Related Issue

- Fixes #47  

## Motivation and Context

Previously, plugins wishing to register their own configuration, select a config back end, or specify permission tokens faced architectural coupling:  
- Parameter types used in `IConfigServiceParams` implementations were defined only in the main PlugHub or config service projects.  
- Plugins were forced to reference forbidden host code, violating modular architecture and blocking third-party extensibility.

Extracting these record types to `PlugHub.Shared.Models.Configuration` delivers proper separation-of-concerns, allows plugins to interact with the config system, and enables future provider types or parameters to be added with minimal friction.

## How Has This Been Tested?

- **Solution-wide replacement** of configuration parameter types in the service implementations, application host, and all affected unit tests to use the shared versions.
- **Full compilation and execution** of regression test suites in `PlugHub.UnitTests`, ensuring all existing and migrated references operate without error.
- **Manual smoke checks** of config registration paths (including for existing services and plugin consumers) to validate type access and behavior.
- **Visual inspection** ensuring no lingering references or duplicates exist in service projects.

## Screenshots

_N/A._

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Asset change (adds or updates icons, templates, or other assets)
- [ ] Documentation change (adds or updates documentation)
- [ ] Plugin change (adds or updates a plugin)

## Checklist

- [x] I have read the **CONTRIBUTING** document.
- [x] My change requires a change to the core logic.
    - [x] I have linked the project issue above.
- [ ] My change requires a change to the assets.
    - [ ] I have linked the asset issue above.
- [ ] My change requires a change to the documentation.
    - [ ] I have linked the documentation issue above.
- [ ] My change requires a change to a plugin.
    - [ ] I have linked the plugin issue above.