### PR TITLE
Updated Collection Properties Binding

### DIFF
--- a/PlugHub.UnitTests/Services/Configuration/FileConfigServiceTests.cs
+++ b/PlugHub.UnitTests/Services/Configuration/FileConfigServiceTests.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
 using PlugHub.Models;
 using PlugHub.Services;
 using PlugHub.Services.Configuration;
@@ -7,6 +8,7 @@ using PlugHub.Shared.Interfaces.Models;
 using PlugHub.Shared.Interfaces.Services;
 using PlugHub.Shared.Models;
 using PlugHub.Shared.Models.Configuration;
+using System.Text.Json;
 
 namespace PlugHub.UnitTests.Services.Configuration
 {
@@ -23,17 +25,38 @@ namespace PlugHub.UnitTests.Services.Configuration
         private ITokenSet tokenSet = new TokenSet();
 
 
+        internal class UnitTestConfigItem(string name = "Unknown")
+        {
+            public UnitTestConfigItem() : this("Unknown") { }
+            public string Name { get; set; } = name;
+        }
+
         internal class UnitTestAConfig
         {
             public int FieldA { get; set; } = 50;
             public bool FieldB { get; set; } = false;
             public float FieldC { get; } = 2.71828f;
+            public List<UnitTestConfigItem> SampleList { get; set; } =
+            [
+                new UnitTestConfigItem("TestValueA1"),
+                new UnitTestConfigItem("TestValueA2"),
+                new UnitTestConfigItem("TestValueA3")
+            ];
+
         }
         internal class UnitTestBConfig
         {
             public required string FieldA { get; set; } = "plughub";
             public int FieldB { get; set; } = 100;
             public float FieldC { get; } = 3.14f;
+
+            public Dictionary<string, UnitTestConfigItem> SampleDictionary { get; set; } =
+                new Dictionary<string, UnitTestConfigItem>
+                {
+                    { "Key1", new UnitTestConfigItem("DictValue1") },
+                    { "Key2", new UnitTestConfigItem("DictValue2") },
+                    { "Key3", new UnitTestConfigItem("DictValue3") }
+                };
         }
 
 
@@ -382,6 +405,49 @@ namespace PlugHub.UnitTests.Services.Configuration
             // Assert
             Assert.ThrowsException<KeyNotFoundException>(() =>
                 this.configService!.GetDefaultConfigFileContents(typeof(UnitTestAConfig), this.tokenSet));
+        }
+
+        [TestMethod]
+        [TestCategory("Mutators")]
+        public void SetSetting_ListProperty_UpdatesListAndFiresEvent()
+        {
+            // Arrange
+            bool eventFired = false;
+            this.configService!.SettingChanged += (s, e) => eventFired = true;
+            List<string> testList = ["one", "two", "three"];
+
+            // Act
+            this.configService!.RegisterConfigs([typeof(UnitTestAConfig)], this.fileParams);
+            this.configService!.SetSetting(typeof(UnitTestAConfig), "SampleList", testList, this.tokenSet);
+
+            List<string> value = this.configService!.GetSetting<List<string>>(typeof(UnitTestAConfig), "SampleList", this.tokenSet);
+
+            // Assert
+            CollectionAssert.AreEqual(testList, value);
+            Assert.IsTrue(eventFired, "Setting changes should fire events");
+        }
+
+        [TestMethod]
+        [TestCategory("Mutators")]
+        public void SetSetting_BindsDictionaryPropertyCorrectly()
+        {
+            // Arrange
+            Dictionary<string, UnitTestConfigItem> expectedDict = new()
+            {
+                { "Key1", new UnitTestConfigItem("NewValue1") },
+                { "Key2", new UnitTestConfigItem("NewValue2") },
+                { "Key3", new UnitTestConfigItem("NewValue3") }
+            };
+
+            this.configService!.RegisterConfigs([typeof(UnitTestBConfig)], this.fileParams);
+
+            // Act
+            this.configService!.SetSetting(typeof(UnitTestBConfig), "SampleDictionary", expectedDict, this.tokenSet);
+            Dictionary<string, UnitTestConfigItem> actualDict = this.configService!.GetSetting<Dictionary<string, UnitTestConfigItem>>(typeof(UnitTestBConfig), "SampleDictionary", this.tokenSet);
+
+            // Assert
+            Assert.AreEqual(3, actualDict.Count);
+            Assert.AreEqual("NewValue2", actualDict["Key2"].Name);
         }
 
         #endregion


### PR DESCRIPTION
## Description

This pull request addresses a critical issue in PlugHub’s configuration system where properties of type `List` in configuration POCOs were not correctly populated or overridden when loaded or merged from configuration sources, including user-level overrides. The root cause was the use of the non-generic configuration binding method `.Get(Type)`, which does not recursively bind nested collections. The fix introduces explicit handling for `List` properties by creating each list element via reflection and binding its properties individually with `.Bind()`. This ensures proper deserialization and overrides for all complex list types during configuration loading.

## Related Issue

- Fixes #49

## Motivation and Context

This change is required because plugins and core features depend on configuration objects that may contain collection properties. Without proper binding, list properties either remained empty or were not overridden by user settings, causing configuration inconsistencies and broken features. This patch makes list binding robust, enabling full reliability for lists in all config scenarios. Dictionary support currently remains adequate with the default binder.

## How Has This Been Tested?

- Added and/or updated unit tests in `FileConfigServiceTests` and `UserConfigServiceTests` to cover:
  - Setting and retrieving `List` properties in config POCOs.
  - Verifying user-level overrides supersede default values for lists.
  - Confirming correct event firing (where relevant) on list changes.
  - Including dictionary tests to confirm default .NET binder support for dictionary properties is still functional.
- Changes confirmed on current .NET runtime in both system and user config scenarios.

## Screenshots (if appropriate)

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Asset change (adds or updates icons, templates, or other assets)
- [ ] Documentation change (adds or updates documentation)
- [ ] Plugin change (adds or updates a plugin)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My change requires a change to the core logic.
    - [x] I have linked the project issue above.
- [ ] My change requires a change to the assets.
    - [ ] I have linked the asset issue above.
- [ ] My change requires a change to the documentation.
    - [ ] I have linked the documentation issue above.
- [ ] My change requires a change to a plugin.
    - [ ] I have linked the plugin issue above.