### PR TITLE
Added "Try" Methods and Predicate to Configuration Service

### DIFF
--- a/PlugHub.Shared/Interfaces/Services/Configuration/IConfigService.cs
+++ b/PlugHub.Shared/Interfaces/Services/Configuration/IConfigService.cs
@@ -164,6 +164,12 @@ namespace PlugHub.Shared.Interfaces.Services.Configuration
         /// <summary>Gets the platform-specific data directory.</summary>
         public string ConfigDataDirectory { get; }
 
+        #region COnfigService: Predicates
+
+        bool IsConfigRegistered(Type configType);
+
+        #endregion
+
         #region ConfigService: Accessors
 
         /// <summary>
@@ -227,7 +233,6 @@ namespace PlugHub.Shared.Interfaces.Services.Configuration
 
         #endregion
 
-
         #region IConfigService: Registration
 
         /// <summary>
@@ -277,6 +282,36 @@ namespace PlugHub.Shared.Interfaces.Services.Configuration
 
 
         /// <summary>
+        /// Attempts to register a single configuration type with the configuration service.
+        /// </summary>
+        /// <param name="configType">The <see cref="Type"/> representing the configuration section to register.</param>
+        /// <param name="configParams">An <see cref="IConfigServiceParams"/> instance used to select the config provider and configure registration behavior.</param>
+        /// <returns>
+        /// <see langword="true"/> if registration succeeded; <see langword="false"/> if the configuration type is already registered 
+        /// or no provider is registered for the params type, or an error occurred.
+        /// </returns>
+        /// <remarks>
+        /// This method calls <see cref="RegisterConfig(Type, IConfigServiceParams)"/> internally and catches exceptions.
+        /// </remarks>
+        bool TryRegisterConfig(Type configType, IConfigServiceParams configParams);
+
+        /// <summary>
+        /// Attempts to register a single configuration type with parameters and outputs a typed accessor for it.
+        /// </summary>
+        /// <typeparam name="TConfig">The configuration type to register.</typeparam>
+        /// <param name="configParams">Parameters guiding registration and accessor behavior.</param>
+        /// <param name="accessor">When this method returns, contains the typed accessor if registration succeeded; otherwise, <see langword="null"/>.</param>
+        /// <returns>
+        /// <see langword="true"/> if registration succeeded and accessor is provided; <see langword="false"/> if the configuration type is already registered
+        /// or no provider is registered for the params type, or an error occurred.
+        /// </returns>
+        /// <remarks>
+        /// This method calls <see cref="RegisterConfig{TConfig}(IConfigServiceParams, out IConfigAccessorFor{TConfig})"/> internally and catches exceptions.
+        /// </remarks>
+        bool TryRegisterConfig<TConfig>(IConfigServiceParams configParams, out IConfigAccessorFor<TConfig>? accessor) where TConfig : class;
+
+
+        /// <summary>
         /// Unregisters a single configuration type from the service, removing all associated settings and change listeners.
         /// </summary>
         /// <param name="configType">The <see cref="Type"/> of the configuration to unregister.</param>
@@ -310,6 +345,29 @@ namespace PlugHub.Shared.Interfaces.Services.Configuration
         /// <exception cref="ArgumentNullException"/>
         /// <exception cref="UnauthorizedAccessException"/>
         public void UnregisterConfigs(IEnumerable<Type> configTypes, ITokenSet tokenSet);
+
+
+        /// <summary>
+        /// Attempts to unregister a single configuration type from the service.
+        /// </summary>
+        /// <param name="configType">The <see cref="Type"/> of the configuration to unregister.</param>
+        /// <param name="token">Optional token for owner operations. Defaults to a new <see cref="Token"/> if not specified.</param>
+        /// <returns><see langword="true"/> if unregistration succeeded; otherwise, <see langword="false"/>.</returns>
+        /// <remarks>
+        /// This method calls <see cref="UnregisterConfig(Type, Token?)"/> internally and catches exceptions.
+        /// </remarks>
+        bool TryUnregsterConfig(Type configType, Token? token = null);
+
+        /// <summary>
+        /// Attempts to unregister a single configuration type from the service using a consolidated token set.
+        /// </summary>
+        /// <param name="configType">The <see cref="Type"/> of the configuration to unregister.</param>
+        /// <param name="tokenSet">Consolidated token container for owner/read/write permissions.</param>
+        /// <returns><see langword="true"/> if unregistration succeeded; otherwise, <see langword="false"/>.</returns>
+        /// <remarks>
+        /// This method calls <see cref="UnregisterConfig(Type, ITokenSet)"/> internally and catches exceptions.
+        /// </remarks>
+        bool TryUnregsterConfig(Type configType, ITokenSet tokenSet);
 
         #endregion
 

--- a/PlugHub/Services/Configuration/ConfigProviderBase.cs
+++ b/PlugHub/Services/Configuration/ConfigProviderBase.cs
@@ -21,7 +21,7 @@ using System.Threading.Tasks;
 
 namespace PlugHub.Services.Configuration
 {
-    public abstract class ConfigServiceBase : IConfigServiceProvider, IDisposable
+    public abstract class ConfigProviderBase : IConfigServiceProvider, IDisposable
     {
         private class ConfigChangeContext(Type configType, ReaderWriterLockSlim configLock, UserConfigServiceConfig? config, bool configFound)
         {
@@ -43,7 +43,7 @@ namespace PlugHub.Services.Configuration
         protected JsonSerializerOptions JsonOptions { get; init; } = new JsonSerializerOptions();
         protected bool IsDisposed = false;
 
-        public ConfigServiceBase(ILogger<IConfigServiceProvider> logger, ITokenService tokenService)
+        public ConfigProviderBase(ILogger<IConfigServiceProvider> logger, ITokenService tokenService)
         {
             ArgumentNullException.ThrowIfNull(logger);
             ArgumentNullException.ThrowIfNull(tokenService);

--- a/PlugHub/Services/Configuration/Providers/FileConfigService.cs
+++ b/PlugHub/Services/Configuration/Providers/FileConfigService.cs
@@ -19,16 +19,7 @@ using System.Threading.Tasks;
 
 namespace PlugHub.Services.Configuration.Providers
 {
-    public class FileConfigServiceConfig(
-        IConfigService configService,
-        string configPath,
-        IConfiguration config,
-        Dictionary<string, object?> values,
-        JsonSerializerOptions? jsonOptions,
-        Token ownerToken,
-        Token readToken,
-        Token writeToken,
-        bool reloadOnChanged)
+    public class FileConfigServiceConfig(IConfigService configService, string configPath, IConfiguration config, Dictionary<string, object?> values, JsonSerializerOptions? jsonOptions, Token ownerToken, Token readToken, Token writeToken, bool reloadOnChanged)
     {
         public IConfigService ConfigService { get; init; } = configService ?? throw new ArgumentNullException(nameof(configService));
         public string ConfigPath { get; init; } = configPath ?? throw new ArgumentNullException(nameof(configPath));
@@ -53,7 +44,7 @@ namespace PlugHub.Services.Configuration.Providers
         public bool WriteAccess { get; init; } = writeValue;
     }
 
-    public class FileConfigService : ConfigServiceBase, IConfigServiceProvider, IDisposable
+    public class FileConfigService : ConfigProviderBase, IConfigServiceProvider, IDisposable
     {
         public FileConfigService(ILogger<IConfigServiceProvider> logger, ITokenService tokenService)
             : base(logger, tokenService)
@@ -695,22 +686,22 @@ namespace PlugHub.Services.Configuration.Providers
                 if (value == null)
                 {
                     bool canAcceptNull = !prop.PropertyType.IsValueType || Nullable.GetUnderlyingType(prop.PropertyType) != null;
+                    bool isCollection = typeof(IEnumerable).IsAssignableFrom(prop.PropertyType) && prop.PropertyType != typeof(string);
 
-                    if (canAcceptNull)
+                    if (canAcceptNull && !isCollection)
                     {
                         prop.SetValue(instance, null);
                     }
+
                     return;
                 }
 
                 if (prop.PropertyType.IsEnum)
                 {
                     bool enumValueIsValid = Enum.IsDefined(prop.PropertyType, value);
-
                     object enumValue = enumValueIsValid
                         ? Enum.ToObject(prop.PropertyType, value)
                         : Activator.CreateInstance(prop.PropertyType)!;
-
                     prop.SetValue(instance, enumValue);
                 }
                 else if (prop.PropertyType.IsInstanceOfType(value))

--- a/PlugHub/Services/Configuration/Providers/UserFileConfigService.cs
+++ b/PlugHub/Services/Configuration/Providers/UserFileConfigService.cs
@@ -32,7 +32,7 @@ namespace PlugHub.Services.Configuration.Providers
         public object? UserValue { get; set; } = userValue;
     }
 
-    public class UserFileConfigService : ConfigServiceBase, IConfigServiceProvider, IDisposable
+    public class UserFileConfigService : ConfigProviderBase, IConfigServiceProvider, IDisposable
     {
         public UserFileConfigService(ILogger<IConfigServiceProvider> logger, ITokenService tokenService)
             : base(logger, tokenService)


### PR DESCRIPTION
## Description
This change introduces safe "Try" style registration and unregistration methods to the IConfigService interface and its implementation in ConfigService. The new methods (`TryRegisterConfig` and `TryUnregsterConfig`) allow clients to attempt configuration registration and unregistration without exceptions, returning a boolean to indicate success. Additionally, a predicate method `IsConfigRegistered` was added to check if a configuration type is already registered. The ConfigService class also gained a static helper method, `GetInstance`, for dependency-injection based construction. Furthermore, base classes for configuration providers were refactored for better separation, and null-handling behavior was improved in FileConfigService to prevent setting null on collection properties.

## Related Issue
- Resolves #58

## Motivation and Context
The existing registration and unregistration operations throw exceptions on failure, which can complicate client error handling and reduce API usability. Adding safe "Try" methods simplifies client interaction by providing non-throwing options with clear success feedback. The predicate method enables clients to verify registration state before attempting changes. The DI-friendly static construction helper eases integration into dependency injection pipelines. These additions enhance robustness, clarity, and developer experience across the configuration service.

## How Has This Been Tested?
The changes were tested with unit tests covering registration and unregistration both in normal and failure scenarios, ensuring the "Try" methods correctly return success status without throwing exceptions. Predicate checks were validated for correct presence reporting of registered types. The static DI construction was tested by initializing the ConfigService with a service collection in sample applications. Refactored provider base class functionality was verified to maintain existing behavior. Null handling in FileConfigService was tested to confirm collections are not set to null erroneously.

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Asset change (adds or updates icons, templates, or other assets)
- [ ] Documentation change (adds or updates documentation)
- [ ] Plugin change (adds or updates a plugin)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My change requires a change to the core logic.
    - [x] I have linked the project issue above.
- [ ] My change requires a change to the assets.
    - [ ] I have linked the asset issue above.
- [ ] My change requires a change to the documentation.
    - [ ] I have linked the documentation issue above.
- [ ] My change requires a change to a plugin.
    - [ ] I have linked the plugin issue above.