### PR TITLE
Renamed ProvidesDescriptorAttribute to DescriptorProviderAttribute

### DIFF
--- a/PlugHub.Shared/Attributes/DescriptorProviderAttribute.cs
+++ b/PlugHub.Shared/Attributes/DescriptorProviderAttribute.cs
@@ -1,7 +1,7 @@
 ﻿namespace PlugHub.Shared.Attributes
 {
     [AttributeUsage(AttributeTargets.Interface, Inherited = false)]
-    public sealed class ProvidesDescriptorAttribute(string descriptorAccessorName, bool descriptorIsOrdered = true) : Attribute
+    public sealed class DescriptorProviderAttribute(string descriptorAccessorName, bool descriptorIsOrdered = true) : Attribute
     {
         public string DescriptorAccessorName { get; } = descriptorAccessorName;
         public bool DescriptorIsOrdered { get; } = descriptorIsOrdered;

--- a/PlugHub.Shared/Interfaces/Plugins/IPluginAppConfig.cs
+++ b/PlugHub.Shared/Interfaces/Plugins/IPluginAppConfig.cs
@@ -32,7 +32,7 @@ namespace PlugHub.Shared.Interfaces.Plugins
     /// Interface for plugins that supply branding assets, configuration and/or metadata.
     /// Provides descriptors for visual, branding, and identity-related resources included with the plugin.
     /// </summary>
-    [ProvidesDescriptor("GetAppConfigDescriptors", false)]
+    [DescriptorProvider("GetAppConfigDescriptors", false)]
     public interface IPluginAppConfig : IPlugin
     {
         /// <summary>

--- a/PlugHub.Shared/Interfaces/Plugins/IPluginConfiguration.cs
+++ b/PlugHub.Shared/Interfaces/Plugins/IPluginConfiguration.cs
@@ -34,7 +34,7 @@ namespace PlugHub.Shared.Interfaces.Plugins
     /// Interface for plugins that register configuration options.
     /// Provides metadata describing configuration settings.
     /// </summary>
-    [ProvidesDescriptor("GetConfigurationDescriptors", false)]
+    [DescriptorProvider("GetConfigurationDescriptors", false)]
     public interface IPluginConfiguration : IPlugin
     {
         /// <summary>

--- a/PlugHub.Shared/Interfaces/Plugins/IPluginDependencyInjection.cs
+++ b/PlugHub.Shared/Interfaces/Plugins/IPluginDependencyInjection.cs
@@ -38,7 +38,7 @@ namespace PlugHub.Shared.Interfaces.Plugins
     /// Interface for plugins that participate in dependency injection.
     /// Provides descriptors for services the plugin injects into the host or other plugins.
     /// </summary>
-    [ProvidesDescriptor("GetInjectionDescriptors", false)]
+    [DescriptorProvider("GetInjectionDescriptors", false)]
     public interface IPluginDependencyInjection : IPlugin
     {
         /// <summary>

--- a/PlugHub.Shared/Utility/Atomic.cs
+++ b/PlugHub.Shared/Utility/Atomic.cs
@@ -31,9 +31,7 @@ namespace PlugHub.Shared.Utility
             bool directoryExists = Directory.Exists(dir);
 
             if (!directoryExists)
-            {
                 Directory.CreateDirectory(dir);
-            }
 
             string tempPath = Path.Combine(dir, Guid.NewGuid().ToString("N") + ".tmp");
             File.WriteAllBytes(tempPath, data.ToArray());
@@ -61,7 +59,6 @@ namespace PlugHub.Shared.Utility
 
                 try
                 {
-                    // Stage 1: Write to temporary file with optimal settings
                     await using (FileStream fs = new(
                         tempPath,
                         FileMode.Create,
@@ -73,17 +70,12 @@ namespace PlugHub.Shared.Utility
                         await fs.WriteAsync(bytes, cancellationToken);
                     }
 
-                    // Stage 2: Atomically move to final destination
                     bool destinationExists = File.Exists(destinationPath);
 
                     if (destinationExists)
-                    {
                         File.Replace(tempPath, destinationPath, null, ignoreMetadataErrors: true);
-                    }
                     else
-                    {
                         File.Move(tempPath, destinationPath);
-                    }
 
                     return;
                 }
@@ -99,7 +91,6 @@ namespace PlugHub.Shared.Utility
                 cancellationToken.ThrowIfCancellationRequested();
             }
 
-            // Stage 3: Throw exception for max retries exceeded
             throw new IOException($"Unable to write '{destinationPath}' after {maxRetries} attempts.");
         }
 
@@ -111,9 +102,7 @@ namespace PlugHub.Shared.Utility
             string? dir = Path.GetDirectoryName(path);
 
             if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
-            {
                 Directory.CreateDirectory(dir);
-            }
         }
 
         private static void CleanupTempFile(string tempPath)
@@ -121,15 +110,11 @@ namespace PlugHub.Shared.Utility
             try
             {
                 bool tempFileExists = File.Exists(tempPath);
+
                 if (tempFileExists)
-                {
                     File.Delete(tempPath);
-                }
             }
-            catch
-            {
-                // Cleanup failures are non-critical - ignored intentionally
-            }
+            catch { /* Nothing to see here */ }
         }
 
         #endregion

--- a/PlugHub/Services/Plugins/PluginRegistrar.cs
+++ b/PlugHub/Services/Plugins/PluginRegistrar.cs
@@ -104,12 +104,12 @@ namespace PlugHub.Services.Plugins
                         continue;
                     }
 
-                    ProvidesDescriptorAttribute? attr = null;
+                    DescriptorProviderAttribute? attr = null;
                     Type[] allInterfaces = [pluginInterface.InterfaceType, .. pluginInterface.InterfaceType.GetInterfaces()];
 
                     foreach (Type it in allInterfaces)
                     {
-                        attr = it.GetCustomAttribute<ProvidesDescriptorAttribute>(inherit: false);
+                        attr = it.GetCustomAttribute<DescriptorProviderAttribute>(inherit: false);
                         if (attr != null)
                             break;
                     }

--- a/PlugHub/Services/Plugins/PluginService.cs
+++ b/PlugHub/Services/Plugins/PluginService.cs
@@ -210,13 +210,13 @@ namespace PlugHub.Services.Plugins
 
             foreach (Type interfaceType in pluginInterfaceTypes)
             {
-                ProvidesDescriptorAttribute? attr = null;
+                DescriptorProviderAttribute? attr = null;
 
                 Type[] allInterfaces = [interfaceType, .. interfaceType.GetInterfaces()];
 
                 foreach (Type it in allInterfaces)
                 {
-                    attr = it.GetCustomAttribute<ProvidesDescriptorAttribute>(inherit: false);
+                    attr = it.GetCustomAttribute<DescriptorProviderAttribute>(inherit: false);
                     if (attr != null)
                         break;
                 }


### PR DESCRIPTION
## Description
Renamed `ProvidesDescriptorAttribute` to `DescriptorProviderAttribute` in `PlugHub.Shared/Attributes`.  
This includes:
- Updating the file name to `DescriptorProviderAttribute.cs`
- Replacing all references across the solution
- Adjusting related tests and documentation

## Related Issue
- Resolves #62

## Motivation and Context
The new naming improves clarity and aligns with common .NET attribute naming conventions (noun-based + `Attribute` suffix).  
This reduces confusion and makes the attribute’s purpose clearer to contributors.

## How Has This Been Tested?
- Built the solution successfully after renaming
- Verified all unit tests pass
- Performed a solution-wide search to confirm old references have been updated

## Screenshots (if appropriate):
N/A

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Asset change (adds or updates icons, templates, or other assets)
- [ ] Documentation change (adds or updates documentation)
- [ ] Plugin change (adds or updates a plugin)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My change requires a change to the core logic.
    - [x] I have linked the project issue above.
- [ ] My change requires a change to the assets.
    - [ ] I have linked the asset issue above.
- [ ] My change requires a change to the documentation.
    - [ ] I have linked the documentation issue above.
- [ ] My change requires a change to a plugin.
    - [ ] I have linked the plugin issue above.