### PR TITLE
Implements standardized plugin interfaces for UI contributions

### DIFF
--- a/PlugHub.Shared/Interfaces/Plugins/IPluginControls.cs
+++ b/PlugHub.Shared/Interfaces/Plugins/IPluginControls.cs
@@ -1,0 +1,47 @@
+﻿using Avalonia.Controls;
+using PlugHub.Shared.Attributes;
+using PlugHub.Shared.Models.Plugins;
+using PlugHub.Shared.ViewModels;
+
+namespace PlugHub.Shared.Interfaces.Plugins
+{
+    /// <summary>
+    /// Describes a plugin-provided UI content/control, including its types, 
+    /// display name, icon, and factory methods for instantiation.
+    /// </summary>
+    /// <param name="viewType">The concrete type of the Avalonia UserControl.</param>
+    /// <param name="viewModelType">The type of the associated ViewModel.</param>
+    /// <param name="name">Display name for this content/control.</param>
+    /// <param name="iconSource">Resource key or path for the icon.</param>
+    /// <param name="viewFactory">Factory function to create the UserControl instance.</param>
+    /// <param name="viewModelFactory">Factory function to create the ViewModel instance.</param>
+    public record ControlDescsriptor(
+        Guid PluginID,
+        Guid InterfaceID,
+        string Version,
+
+        Type ViewType,
+        Type ViewModelType,
+        string Name,
+        string IconSource,
+        Func<IServiceProvider, UserControl> ViewFactory,
+        Func<IServiceProvider, BaseViewModel> ViewModelFactory,
+
+        IEnumerable<PluginInterfaceReference>? LoadBefore = null,
+        IEnumerable<PluginInterfaceReference>? LoadAfter = null,
+        IEnumerable<PluginInterfaceReference>? DependsOn = null,
+        IEnumerable<PluginInterfaceReference>? ConflictsWith = null) :
+            PluginDescriptor(PluginID, InterfaceID, Version, LoadBefore, LoadAfter, DependsOn, ConflictsWith);
+
+    /// <summary>
+    /// Interface for plugins that provide UI content/controls to the host application.
+    /// </summary>
+    [DescriptorProvider("GetControlDescriptors", false)]
+    public interface IPluginControls : IPlugin
+    {
+        /// <summary>
+        /// Gets the list of content descriptions (controls) provided by this plugin.
+        /// </summary>
+        public List<ControlDescsriptor> GetControlDescriptors();
+    }
+}

--- a/PlugHub.Shared/Interfaces/Plugins/IPluginPages.cs
+++ b/PlugHub.Shared/Interfaces/Plugins/IPluginPages.cs
@@ -1,0 +1,58 @@
+﻿using Avalonia.Controls;
+using PlugHub.Shared.Attributes;
+using PlugHub.Shared.Models.Plugins;
+using PlugHub.Shared.ViewModels;
+
+namespace PlugHub.Shared.Interfaces.Plugins
+{
+    /// <summary>
+    /// Describes a plugin-provided page, including its view, view model, icon, 
+    /// and dependency relationships relative to other pages.
+    /// Contains type and factory information required to create page instances,
+    /// as well as dependency, conflict, and ordering relationships relative to other page providers.
+    /// </summary>
+    /// <param name="PluginID">Unique identifier for the plugin providing this page.</param>
+    /// <param name="InterfaceID">Unique identifier for the interface provided by this descriptor.</param>
+    /// <param name="Version">Version of the providing plugin.</param>
+    /// <param name="ViewType">The concrete type of the Avalonia UserControl for the page.</param>
+    /// <param name="ViewModelType">The type of the associated ViewModel.</param>
+    /// <param name="Name">Display name for the page.</param>
+    /// <param name="IconSource">Resource key or path for the page icon.</param>
+    /// <param name="ViewFactory">Factory function to create the UserControl instance.</param>
+    /// <param name="ViewModelFactory">Factory function to create the ViewModel instance.</param>
+    /// <param name="LoadBefore">Plugins/interface pages that must load after this one.</param>
+    /// <param name="LoadAfter">Plugins/interface pages that must load before this one.</param>
+    /// <param name="DependsOn">Plugins that this page explicitly depends on.</param>
+    /// <param name="ConflictsWith">Plugins that cannot be loaded concurrently with this page.</param>
+    public record PluginPageDescriptor(
+            Guid PluginID,
+            Guid InterfaceID,
+            string Version,
+
+            Type ViewType,
+            Type ViewModelType,
+            string Name,
+            string IconSource,
+            Func<IServiceProvider, UserControl> ViewFactory,
+            Func<IServiceProvider, BaseViewModel> ViewModelFactory,
+
+            IEnumerable<PluginInterfaceReference>? LoadBefore = null,
+            IEnumerable<PluginInterfaceReference>? LoadAfter = null,
+            IEnumerable<PluginInterfaceReference>? DependsOn = null,
+            IEnumerable<PluginInterfaceReference>? ConflictsWith = null) :
+                ControlDescsriptor(PluginID, InterfaceID, Version, ViewType, ViewModelType, Name, IconSource, ViewFactory, ViewModelFactory, LoadBefore, LoadAfter, DependsOn, ConflictsWith);
+
+    /// <summary>
+    /// Interface for plugins that provide pages to the host application.
+    /// Provides descriptors for pages the plugin contributes to the application.
+    /// </summary>
+    [DescriptorProvider("GetPageDescriptors", false)]
+    public interface IPluginPages : IPlugin
+    {
+        /// <summary>
+        /// Returns a collection of descriptors detailing the pages
+        /// provided by this plugin.
+        /// </summary>
+        public IEnumerable<PluginPageDescriptor> GetPageDescriptors();
+    }
+}

--- a/PlugHub.Shared/Interfaces/Plugins/IPluginSettingsPages.cs
+++ b/PlugHub.Shared/Interfaces/Plugins/IPluginSettingsPages.cs
@@ -1,0 +1,57 @@
+﻿using Avalonia.Controls;
+using PlugHub.Shared.Attributes;
+using PlugHub.Shared.Models.Plugins;
+using PlugHub.Shared.ViewModels;
+
+namespace PlugHub.Shared.Interfaces.Plugins
+{
+    /// <summary>
+    /// Describes a plugin-provided page, including its view, view model, group, icon, 
+    /// resource dictionaries, and optional menu bar configuration.
+    /// Inherits from <see cref="ControlDescsriptor"/>.
+    /// </summary>
+    /// <param name="PluginID">Unique identifier for the plugin providing this page.</param>
+    /// <param name="InterfaceID">Unique identifier for the interface provided by this descriptor.</param>
+    /// <param name="Version">Version of the providing plugin.</param>
+    /// <param name="ViewType">The concrete type of the Avalonia <see cref="UserControl"/> representing the page's view.</param>
+    /// <param name="ViewModelType">The type of the associated view model, typically derived from <see cref="ViewModelBase"/>.</param>
+    /// <param name="Group">The logical group for this support page.</param>
+    /// <param name="Name">The display name for the support page, as shown in the UI.</param>
+    /// <param name="IconSource">A resource key or file path for the icon representing this page.</param>
+    /// <param name="ViewFactory">A factory function that creates an instance of the page's <see cref="UserControl"/>. Receives an <see cref="IServiceProvider"/> for dependency injection.</param>
+    /// <param name="ViewModelFactory">A factory function that creates an instance of the page's <see cref="ViewModelBase"/>. Receives an <see cref="IServiceProvider"/> for dependency injection.</param>
+    /// <param name="LoadBefore">Plugins/interface pages that must load after this one.</param>
+    /// <param name="LoadAfter">Plugins/interface pages that must load before this one.</param>
+    /// <param name="DependsOn">Plugins that this page explicitly depends on.</param>
+    /// <param name="ConflictsWith">Plugins that cannot be loaded concurrently with this page.</param>    
+    public record SettingsPageDescriptor(
+        Guid PluginID,
+        Guid InterfaceID,
+        string Version,
+        Type ViewType,
+        Type ViewModelType,
+        string Group,
+        string Name,
+        string IconSource,
+        Func<IServiceProvider, UserControl> ViewFactory,
+        Func<IServiceProvider, BaseViewModel> ViewModelFactory,
+        IEnumerable<PluginInterfaceReference>? LoadBefore = null,
+        IEnumerable<PluginInterfaceReference>? LoadAfter = null,
+        IEnumerable<PluginInterfaceReference>? DependsOn = null,
+        IEnumerable<PluginInterfaceReference>? ConflictsWith = null) :
+            PluginPageDescriptor(PluginID, InterfaceID, Version, ViewType, ViewModelType, Name, IconSource, ViewFactory, ViewModelFactory, LoadBefore, LoadAfter, DependsOn, ConflictsWith);
+
+    /// <summary>
+    /// Interface for plugins that provide settings or configuration pages.
+    /// Implement this interface to register one or more custom settings pages with the host application.
+    /// </summary>
+    [DescriptorProvider("GetSettingsPageDescriptors", false)]
+    public interface IPluginSettingsPages : IPlugin
+    {
+        /// <summary>
+        /// Gets the list of settings pages provided by the plugin.
+        /// Each <see cref="SettingsPageDescriptor"/> describes a single page, including its view, view model, and metadata.
+        /// </summary>
+        public List<SettingsPageDescriptor> GetSettingsPageDescriptors();
+    }
+}

--- a/PlugHub.Shared/Interfaces/Plugins/IPluginStyleInclusion.cs
+++ b/PlugHub.Shared/Interfaces/Plugins/IPluginStyleInclusion.cs
@@ -1,0 +1,46 @@
+﻿using PlugHub.Shared.Attributes;
+using PlugHub.Shared.Models.Plugins;
+
+
+namespace PlugHub.Shared.Interfaces.Plugins
+{
+    /// <summary>
+    /// Describes a plugin component that provides Avalonia StyleInclude resources (AXAML files)
+    /// that must be loaded before the main UI initializes.
+    /// Declares all dependency and ordering relationships for conflict-free, deterministic style loading.
+    /// </summary>
+    /// <param name="PluginID">Unique identifier for the style-providing plugin.</param>
+    /// <param name="InterfaceID">Unique identifier for the interface provided by this descriptor.</param>
+    /// <param name="Version">Version of the style include descriptor.</param>
+    /// <param name="ResourceUri">URI of the AXAML resource to be loaded as a StyleInclude.</param>
+    /// <param name="BaseUri">Base URI for resolving relative resource paths (defaults to plugin's base URI).</param>
+    /// <param name="LoadBefore">Style descriptors that should be loaded after this one.</param>
+    /// <param name="LoadAfter">Style descriptors that should be loaded before this one.</param>
+    /// <param name="DependsOn">Style resources/descriptors that this style depends on.</param>
+    /// <param name="ConflictsWith">Style resources that cannot coexist with this descriptor.</param>
+    public record PluginStyleIncludeDescriptor(
+        Guid PluginID,
+        Guid InterfaceID,
+        string Version,
+        string ResourceUri,
+        string? BaseUri = null,
+        IEnumerable<PluginInterfaceReference>? LoadBefore = null,
+        IEnumerable<PluginInterfaceReference>? LoadAfter = null,
+        IEnumerable<PluginInterfaceReference>? DependsOn = null,
+        IEnumerable<PluginInterfaceReference>? ConflictsWith = null) :
+            PluginDescriptor(PluginID, InterfaceID, Version, LoadBefore, LoadAfter, DependsOn, ConflictsWith);
+
+    /// <summary>
+    /// Interface for plugins that supply Avalonia StyleInclude resources.
+    /// Provides descriptors for AXAML style files that need to be loaded during application bootstrap.
+    /// </summary>
+    [DescriptorProvider("GetStyleIncludeDescriptors", false)]
+    public interface IPluginStyleInclusion : IPlugin
+    {
+        /// <summary>
+        /// Returns a collection of descriptors defining StyleInclude resources
+        /// (AXAML files containing styles, themes, or resource dictionaries) offered by this plugin.
+        /// </summary>
+        IEnumerable<PluginStyleIncludeDescriptor> GetStyleIncludeDescriptors();
+    }
+}


### PR DESCRIPTION
## Description
This PR introduces a set of plugin interfaces in the `PlugHub.Shared` project that allow plugins to contribute user interface elements to the host application in a structured and extensible way.  

The following interfaces and supporting descriptors have been added:
- **`IPluginStyleInclusion`** – enables plugins to register `StyleInclude` resources (themes, icon sets, etc.).  
- **`IPluginPages`** – provides a contract for contributing navigation pages (views, viewmodels, and metadata) to the application's main `NavigationView`.  
- **`IPluginSettingsPages`** – defines contributions of plugin-specific configuration pages to the host’s Settings hub.  
- **Descriptor classes** (`PluginStyleIncludeDescriptor`, `PluginPageDescriptor`, `SettingsPageDescriptor`) encapsulate metadata for each plugin contribution.

## Related Issue
- Resolves: #67 

## Motivation and Context
Currently, plugin developers do not have a standardized way to contribute UI components to the host app. Each plugin has to integrate in an ad-hoc manner, creating tight coupling and maintenance challenges.  

By introducing these interfaces, we provide:
- A **clear, extensible contract** for contributing styles, navigation, and settings pages.  
- The ability for **plugins to dynamically register UI** components without requiring host modifications.  
- A **scalable foundation** for plugin-driven UI extensibility moving forward.

## How Has This Been Tested?
- NA

## Screenshots (if appropriate):
- NA

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Asset change (adds or updates icons, templates, or other assets)
- [ ] Documentation change (adds or updates documentation)
- [ ] Plugin change (adds or updates a plugin)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My change requires a change to the core logic.
    - [x] I have linked the project issue above.
- [ ] My change requires a change to the assets.
    - [ ] I have linked the asset issue above.
- [ ] My change requires a change to the documentation.
    - [ ] I have linked the documentation issue above.
- [ ] My change requires a change to a plugin.
    - [ ] I have linked the plugin issue above.
