### PR TITLE
Enforces Unique Plugin IDs in the Plugin Loader

### DIFF
--- a/PlugHub/Bootstrap/Bootstrapper.cs
+++ b/PlugHub/Bootstrap/Bootstrapper.cs
@@ -351,7 +351,7 @@ namespace PlugHub.Bootstrap
 
                         configChanged = true;
 
-                        Log.Information("[Bootstrapper] Added new config entry for {AssemblyName}:{TypeName}:{ImplementationName}", pluginInterface.AssemblyName, pluginInterface.ImplementationName, pluginInterface.InterfaceName);
+                        Log.Debug("[Bootstrapper] Added new config entry for {AssemblyName}:{TypeName}:{ImplementationName}", pluginInterface.AssemblyName, pluginInterface.ImplementationName, pluginInterface.InterfaceName);
                     }
                 }
             }

--- a/PlugHub/ViewModels/Pages/SettingsPluginsViewModel.cs
+++ b/PlugHub/ViewModels/Pages/SettingsPluginsViewModel.cs
@@ -368,7 +368,7 @@ namespace PlugHub.ViewModels.Pages
 
             this.isUpdating = true;
 
-            foreach (var pluginVm in this.Plugins)
+            foreach (PluginViewModel pluginVm in this.Plugins)
             {
                 if (pluginVm.ProvidedDescriptors != null && pluginVm.ProvidedDescriptors.Any())
                 {


### PR DESCRIPTION
## Description
This change enhances the plugin loading process by enforcing the uniqueness of PluginID metadata. During plugin grouping, the loader now tracks seen PluginIDs using a HashSet and excludes duplicate plugins, logging a warning for each duplicate detected. This helps prevent ambiguous or conflicting plugin identification that could arise from duplicated PluginIDs across different assemblies.

## Related Issue
- Resolves #81 

## Motivation and Context
Currently, the plugin loader does not validate or enforce unique PluginIDs, assuming assemblies provide uniqueness implicitly. This assumption can cause conflicts and unpredictable behavior when plugins share IDs. This change aligns the loader behavior with the expected uniqueness constraint, improving robustness and maintainability of the plugin system.

## How Has This Been Tested?
The change was tested by loading multiple plugins with both unique and duplicate PluginIDs to verify that duplicates are detected, logged as warnings, and not added multiple times. Existing test methods are expected to be updated for comprehensive validation alongside other relevant PRs.

## Screenshots (if appropriate):
- NA

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Asset change (adds or updates icons, templates, or other assets)
- [ ] Documentation change (adds or updates documentation)
- [ ] Plugin change (adds or updates a plugin)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My change requires a change to the core logic.
    - [x] I have linked the project issue above.
- [ ] My change requires a change to the assets.
    - [ ] I have linked the asset issue above.
- [ ] My change requires a change to the documentation.
    - [ ] I have linked the documentation issue above.
- [ ] My change requires a change to a plugin.
    - [ ] I have linked the plugin issue above.
