### PR TITLE
Added Async Save to PluginRegistrar

### DIFF
--- a/PlugHub.Shared/Interfaces/Services/Plugins/IPluginRegistrar.cs
+++ b/PlugHub.Shared/Interfaces/Services/Plugins/IPluginRegistrar.cs
@@ -1,4 +1,5 @@
 ﻿using PlugHub.Shared.Models.Plugins;
+
 namespace PlugHub.Shared.Interfaces.Services.Plugins
 {
     /// <summary>
@@ -29,10 +30,34 @@ namespace PlugHub.Shared.Interfaces.Services.Plugins
         public PluginManifest GetManifest();
 
         /// <summary>
-        /// Persists the given plugin manifest to the underlying storage,
+        /// Persists the given <see cref="PluginManifest"/> to the underlying storage.
         /// </summary>
-        /// <param name="manifest">The <see cref="PluginManifest"/> instance containing updated interface states.</param>
+        /// <param name="manifest">
+        /// The <see cref="PluginManifest"/> instance containing updated interface states to write.
+        /// </param>
+        /// <remarks>
+        /// This is the synchronous entry point.  
+        /// It delegates to <see cref="SaveManifestAsync(PluginManifest)"/> but blocks on completion.  
+        /// Use this method only when calling code cannot be async (e.g., constructors, legacy APIs).  
+        /// For new code paths, prefer the async version to avoid blocking the thread.
+        /// </remarks>
+        /// <exception cref="ArgumentException">Thrown if the manifest is null or contains null <c>InterfaceStates</c>.</exception>
+        /// <exception cref="InvalidOperationException">Propagated if the underlying accessor fails.</exception>
         public void SaveManifest(PluginManifest manifest);
+
+        /// <summary>
+        /// Asynchronously persists the given <see cref="PluginManifest"/> to the underlying storage.
+        /// </summary>
+        /// <param name="manifest">
+        /// The <see cref="PluginManifest"/> instance containing updated interface states to write.
+        /// </param>
+        /// <remarks>
+        /// This is the async-first implementation.  
+        /// It should be preferred in most scenarios as it does not block the calling thread.
+        /// </remarks>
+        /// <exception cref="ArgumentException">Thrown if the manifest is null or contains null <c>InterfaceStates</c>.</exception>
+        /// <exception cref="InvalidOperationException">Propagated if the underlying accessor fails.</exception>
+        public Task SaveManifestAsync(PluginManifest manifest);
 
         /// <summary>
         /// Determines whether a specific plugin interface is currently enabled for a given plugin ID.

--- a/PlugHub/Services/Plugins/PluginRegistrar.cs
+++ b/PlugHub/Services/Plugins/PluginRegistrar.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Threading.Tasks;
 
 namespace PlugHub.Services.Plugins
 {
@@ -81,6 +82,10 @@ namespace PlugHub.Services.Plugins
         }
         public void SaveManifest(PluginManifest manifest)
         {
+            Task.Run(() => this.SaveManifestAsync(manifest)).GetAwaiter().GetResult();
+        }
+        public async Task SaveManifestAsync(PluginManifest manifest)
+        {
             if (manifest?.InterfaceStates == null)
             {
                 this.logger.LogError("[PluginRegistrar] Attempted to save an invalid plugin manifest (null or missing interface states).");
@@ -90,7 +95,7 @@ namespace PlugHub.Services.Plugins
 
             try
             {
-                this.manifestAccessor.Save(manifest);
+                await this.manifestAccessor.SaveAsync(manifest);
 
                 this.logger.LogInformation("[PluginRegistrar] Plugin manifest saved with {Count} interface states.", manifest.InterfaceStates.Count);
             }
@@ -101,7 +106,6 @@ namespace PlugHub.Services.Plugins
                 throw;
             }
         }
-
 
         public List<PluginDescriptor> GetDescriptorsForInterface(Type pluginInterfaceType)
         {


### PR DESCRIPTION
## Description
This PR introduces an asynchronous `SaveManifest` method to the `PluginRegistrar` and `IPluginRegistrar` interfaces.  
- `SaveManifest(PluginManifest manifest)` is a synchronous wrapper that blocks on the asynchronous path.  
- `SaveManifestAsync(PluginManifest manifest)` performs the persistence in a non-blocking manner, making use of `manifestAccessor.SaveAsync()`.  

Both methods include argument validation and proper exception handling to ensure stability.

## Related Issue
- Resolves #83 

## Motivation and Context
Previously, `PluginRegistrar` did not provide explicit entry points for saving manifests synchronously or asynchronously.  
- The **synchronous method** is needed for compatibility with existing synchronous workflows (e.g., constructors, legacy APIs).  
- The **asynchronous method** provides modern, non-blocking behavior that should be preferred in most new usage scenarios.  

Having both available gives plugin developers flexibility, improves reliability, and ensures better lifecycle management of plugin manifests.

## How Has This Been Tested?
Naive testing was performed locally to validate the following:
- `SaveManifest` correctly delegates to and blocks on `SaveManifestAsync`.  
- `SaveManifestAsync` validates input and asynchronously calls `manifestAccessor.SaveAsync()`.  
- Logging and exception handling work as expected.  

A full **MS Test suite** is planned and will be introduced in a subsequent PR to cover these paths with automated unit tests.

## Screenshots (if appropriate):
- N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Asset change (adds or updates icons, templates, or other assets)
- [ ] Documentation change (adds or updates documentation)
- [ ] Plugin change (adds or updates a plugin)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My change requires a change to the core logic.
    - [x] I have linked the project issue above.
- [ ] My change requires a change to the assets.
    - [ ] I have linked the asset issue above.
- [ ] My change requires a change to the documentation.
    - [ ] I have linked the documentation issue above.
- [ ] My change requires a change to a plugin.
    - [ ] I have linked the plugin issue above.
