### PR TITLE
Brought Issue Templates into Alignment with GitHub Linked Issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/report-bug.yml
+++ b/.github/ISSUE_TEMPLATE/report-bug.yml
@@ -1,6 +1,6 @@
 name: Bug Report
 description: Create a report to help us improve PlugHub
-title: "<short summary of your identified issue>"
+title: "<short title for your identified issue>"
 type: bug
 labels: bug
 

--- a/.github/ISSUE_TEMPLATE/request-documentation.md
+++ b/.github/ISSUE_TEMPLATE/request-documentation.md
@@ -1,7 +1,7 @@
 ---
 name: Documentation Request
 about: Request new or improved documentation for PlugHub
-title: "<short summary of your request>"
+title: "<short title for your request>"
 labels: documentation
 ---
 

--- a/.github/ISSUE_TEMPLATE/request-feature.md
+++ b/.github/ISSUE_TEMPLATE/request-feature.md
@@ -1,7 +1,7 @@
 ---
 name: Feature Request
 about: Suggest a feature enhancement for PlugHub
-title: "<short summary of your request>"
+title: "<short title for your request>"
 labels: enhancement
 ---
 
@@ -16,9 +16,6 @@ labels: enhancement
 
 ## Possible Implementation
 <!--- Not obligatory, but suggest an idea for implementing the addition or change. -->
-
-## Related Issues
-<!--- If this feature requires new or changed assets, documentation, or plugins, add the relevant issue links here. -->
 
 ## Target Platform(s)
 <!--- If this feature request is for a specific platform or set of platforms, list them here. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,5 @@
-<!--- Provide a general summary of your changes in the Title above -->
+# Title
+<!--- Provide a concise title for your set of changes -->
 
 ## Description
 <!--- Describe your changes in detail -->
@@ -7,15 +8,16 @@
 <!--- This project only accepts pull requests related to open issues -->
 <!--- If suggesting a new feature or change, please discuss it in an issue first -->
 <!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
-<!--- Please link to the issue, asset, and/or documentation issues here: -->
+<!--- Link the issue here using keywords like "Resolves #123" or "Fixes #123".  
+      This helps automatically close the issue when merged. -->
 
 ## Motivation and Context
 <!--- Why is this change required? What problem does it solve? -->
 
 ## How Has This Been Tested?
-<!--- Please describe in detail how you tested your changes. -->
-<!--- Include details of your testing environment, and the tests you ran to -->
-<!--- see how your change affects other areas of the code, etc. -->
+<!--- Describe in detail how you tested your changes. -->
+<!--- Include information about your testing environment and the test cases you ran. -->
+<!--- Explain how you verified that your change works and does not affect other parts of the code. -->
 
 ## Screenshots (if appropriate):
 
@@ -33,10 +35,10 @@
 <!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
 - [ ] I have read the **CONTRIBUTING** document.
 - [ ] My change requires a change to the core logic.
-    - [ ] I have linked the project issue above.
+  - [ ] I have linked the project issue above.
 - [ ] My change requires a change to the assets.
-    - [ ] I have linked the asset issue above.
+  - [ ] I have linked the asset issue above.
 - [ ] My change requires a change to the documentation.
-    - [ ] I have linked the documentation issue above.
+  - [ ] I have linked the documentation issue above.
 - [ ] My change requires a change to a plugin.
-    - [ ] I have linked the plugin issue above.
+  - [ ] I have linked the plugin issue above.


### PR DESCRIPTION
## Description
This PR cleans up and streamlines the issue and PR templates:
- Replaced "short summary" with "short title" in bug, documentation, and feature request templates to make them more concise and machine-friendly.
- Removed the redundant **Related Issues** section from the feature request template, since GitHub now has a built-in linked issues widget.
- Improved clarity and formatting in the pull request template (title, related issue linking, testing description).
- Adjusted indentation in checklists for consistency.

## Related Issue
- Resolves #85

## Motivation and Context
These changes align our templates with GitHub’s native issue-linking functionality, reducing redundancy and making them more user- and machine-friendly. This cleanup improves readability, encourages better issue linking, and avoids confusion between template sections and GitHub’s UI.

## How Has This Been Tested?
No testing required — this change only affects templates, not executable code.

## Screenshots (if appropriate):
N/A

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Asset change (adds or updates icons, templates, or other assets)
- [x] Documentation change (adds or updates templates and guidance)
- [ ] Plugin change (adds or updates a plugin)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the core logic.
  - [ ] I have linked the project issue above.
- [ ] My change requires a change to the assets.
  - [ ] I have linked the asset issue above.
- [ ] My change requires a change to the documentation.
  - [ ] I have linked the documentation issue above.
- [ ] My change requires a change to a plugin.
  - [ ] I have linked the plugin issue above.
