### PR TITLE
Handled duplicate plugin descriptor IDs in resolution process

### DIFF
--- a/PlugHub.Shared/Models/Plugins/PluginResolutionContext.cs
+++ b/PlugHub.Shared/Models/Plugins/PluginResolutionContext.cs
@@ -3,16 +3,14 @@
 
 namespace PlugHub.Shared.Models.Plugins
 {
-    public class PluginResolutionContext<TDescriptor>(List<TDescriptor> descriptors) where TDescriptor : PluginDescriptor
+    public class PluginResolutionContext<TDescriptor>(List<TDescriptor> descriptors, HashSet<TDescriptor> duplicates) where TDescriptor : PluginDescriptor
     {
-        public Dictionary<Guid, TDescriptor> IdToDescriptor { get; } =
-            descriptors.ToDictionary(d => d.DescriptorID, d => d);
+        public Dictionary<Guid, TDescriptor> IdToDescriptor { get; } = descriptors.ToDictionary(d => d.DescriptorID, d => d);
+        public Dictionary<TDescriptor, HashSet<TDescriptor>> Graph { get; } = descriptors.ToDictionary(d => d, _ => new HashSet<TDescriptor>());
 
         public HashSet<TDescriptor> DependencyDisabled { get; } = [];
         public HashSet<TDescriptor> ConflictDisabled { get; } = [];
-
-        public Dictionary<TDescriptor, HashSet<TDescriptor>> Graph { get; } =
-            descriptors.ToDictionary(d => d, _ => new HashSet<TDescriptor>());
+        public HashSet<TDescriptor> DuplicateIDDisabled { get; } = duplicates;
 
         public IReadOnlyList<TDescriptor> GetSorted()
             => [.. this.Graph.Keys.TopologicalSort(d => this.Graph[d])];

--- a/PlugHub/ViewModels/Pages/SettingsPluginsViewModel.cs
+++ b/PlugHub/ViewModels/Pages/SettingsPluginsViewModel.cs
@@ -471,6 +471,12 @@ namespace PlugHub.ViewModels.Pages
                             ? string.Join(", ", conflictingNames)
                             : "Unknown plugin(s).");
                 }
+                else if (context.DuplicateIDDisabled.Contains(descriptor))
+                {
+                    state = "🌀";
+                    sortOrder = -3;
+                    message = "Ignored due to duplicate DescriptorID.";
+                }
                 else if (sortedIndexLookup.TryGetValue(descriptor, out int index))
                 {
                     sortOrder = index;


### PR DESCRIPTION
## Description
This pull request enhances the `PluginResolver` and related components to handle cases where multiple plugins share the same descriptor ID. Specifically:
- **PluginResolver**
  - Detects duplicate descriptor IDs during resolution.
  - Keeps the first occurrence of a descriptor ID in list order.
  - Excludes subsequent duplicates from the resolved set.
  - Records all duplicates into the `PluginResolutionContext`.
  - Emits log warnings when duplicates are detected, including plugin ID and version context.
- **PluginResolutionContext**
  - Updated constructor to accept a set of duplicate descriptors.
  - Introduced `DuplicateIDDisabled` collection to track duplicates that are excluded.
- **SettingsPluginsViewModel**
  - Adds a visible indicator ("🌀") to surface plugins excluded due to duplicate descriptor IDs.
  - Provides user-facing message: *"Ignored due to duplicate DescriptorID."*

This ensures that plugin resolution no longer fails silently or unpredictably when duplicate IDs are present, and makes conflicts visible to users and administrators for troubleshooting.

## Related Issue
- Resolves #88

## Motivation and Context
When multiple plugins declare the same descriptor ID, it can cause:
- Ambiguity about which plugin instance is actually loaded.
- Difficulty diagnosing misconfigurations.
- Reduced system stability and unpredictable runtime behavior.

This change prevents duplicate descriptor IDs from silently overwriting each other, ensures a deterministic resolution path, and provides visibility of the conflict to administrators via logging and UI indicators.

## How Has This Been Tested?
- Local naive testing performed with sample plugins that intentionally reused descriptor IDs.
- Verified that:
  - The first valid descriptor ID is kept.
  - Subsequent duplicates are excluded and logged.
  - Excluded plugins show the "🌀" marker and corresponding message in the settings UI.
- No regressions observed in dependency resolution or conflict handling behavior.
- A future feature request exists to add formal unit tests for this functionality.

## Screenshots:
- UI now displays "🌀" marker next to plugins excluded for duplicate IDs.
<img width="1426" height="782" alt="plughub-nonunique-descriptor" src="https://github.com/user-attachments/assets/bf96da88-045d-4e53-934b-5b66fe4bfb76" />

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)  
- [x] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to change)  
- [ ] Asset change (adds or updates icons, templates, or other assets)  
- [ ] Documentation change (adds or updates documentation)  
- [ ] Plugin change (adds or updates a plugin)  

## Checklist:
- [x] I have read the **CONTRIBUTING** document.  
- [x] My change requires a change to the core logic.  
  - [x] I have linked the project issue above.  
- [ ] My change requires a change to the assets.  
  - [ ] I have linked the asset issue above.  
- [ ] My change requires a change to the documentation.  
  - [ ] I have linked the documentation issue above.  
- [ ] My change requires a change to a plugin.  
  - [ ] I have linked the plugin issue above.  
