### PR TITLE
Prevented AppConfig corruption caused by plugin-level AppConfig mutations

### DIFF
--- a/PlugHub/Bootstrap/Bootstrapper.cs
+++ b/PlugHub/Bootstrap/Bootstrapper.cs
@@ -40,7 +40,6 @@ namespace PlugHub.Bootstrap
             PluginManifest baseManifest;
             AppConfig sysConfig;
             PluginManifest pluginManifest;
-            AppConfig pluginConfig;
 
             CollectServices(services, tokenSet);
             CollectViewModels(services);
@@ -72,23 +71,15 @@ namespace PlugHub.Bootstrap
 
                 if (!string.IsNullOrWhiteSpace(sysConfig.PluginFolderPath))
                     plugins = RegisterPlugins(tempProvider, services, pluginManifest, sysConfig.PluginFolderPath, plugins);
-            }
-
-            // Build a temporary DI provider including user plugins
-            using (ServiceProvider tempProvider = services.BuildServiceProvider())
-            {
-                // Apply plugin-provided AppConfig mutations 
-                //         (Plugins can override or extend AppConfig here)
-                pluginConfig = PluginsAppConfig(tempProvider, sysConfig);
 
                 // Persist a cache of the loaded plugin references
                 services.AddSingleton<IPluginCache>(new PluginCache(plugins));
 
-                SaveAppConfig(baseConfigService, tokenSet, pluginConfig);
-                SavePluginManifest(baseConfigService, tokenSet, pluginConfig, pluginManifest);
+                SaveAppConfig(baseConfigService, tokenSet, sysConfig);
+                SavePluginManifest(baseConfigService, tokenSet, sysConfig, pluginManifest);
 
                 // Register a ConfigService instance bound to the plugin AppConfig
-                services.AddSingleton(ConfigService.GetInstance(services, pluginConfig));
+                services.AddSingleton(ConfigService.GetInstance(services, sysConfig));
             }
 
             // Build the *final* DI provider including plugins and configs


### PR DESCRIPTION
## Description
This PR removes the ability for non-system plugin AppConfig mutators to alter the persisted AppConfig state during bootstrap. Previously, AppConfig mutations provided by plugins were applied and written back into the persisted config and plugin manifest. This caused inconsistencies across restarts when configuration paths changed, leading to corruption in plugin state management.  
The updated logic ensures that only the system-level AppConfig (`sysConfig`) is persisted, eliminating conflicting writes from plugin-provided AppConfig states.  

## Related Issue
- Fixes #87  

## Motivation and Context
The bug caused scenarios where disabling a mutator plugin did not persist correctly across restarts. This resulted in a failed state where plugins appeared re-enabled on subsequent runs, creating user confusion and loss of control over plugin state.  
By persisting only the authoritative system configuration, we maintain a single source of truth and prevent stale or conflicting AppConfig states.  

## How Has This Been Tested?
- Verified behavior with and without a `AppContext.BaseDirectory` PluginManifest.  
- With a BaseDirectory manifest, AppConfig mutator plugins cause transparent AppConfig mutation as expected.  
- Without a BaseDirectory manifest, AppConfig mutator plugins no longer incorrectly persist altered configuration state.  
- Restart behavior was validated: disabling mutator plugins now persists correctly and is respected consistently across restarts.  

## Screenshots (if appropriate):
- N/A  

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Asset change (adds or updates icons, templates, or other assets)
- [ ] Documentation change (adds or updates documentation)
- [ ] Plugin change (adds or updates a plugin)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.  
- [x] My change requires a change to the core logic.  
  - [x] I have linked the project issue above.  
- [ ] My change requires a change to the assets.  
  - [ ] I have linked the asset issue above.  
- [ ] My change requires a change to the documentation.  
  - [ ] I have linked the documentation issue above.  
- [ ] My change requires a change to a plugin.  
  - [ ] I have linked the plugin issue above.  
