### PR TITLE
Fix missing DataContext assignment for plugin pages and settings pages

### DIFF
--- a/PlugHub/Bootstrap/Bootstrapper.cs
+++ b/PlugHub/Bootstrap/Bootstrapper.cs
@@ -668,11 +668,14 @@ namespace PlugHub.Bootstrap
 
             foreach (PluginPageDescriptor descriptor in sortedDescriptors)
             {
-                mainViewModel.AddMainPageItem(new(descriptor.ViewType, descriptor.ViewModelType, descriptor.Name, descriptor.IconSource)
+                ContentItemViewModel page = new(descriptor.ViewType, descriptor.ViewModelType, descriptor.Name, descriptor.IconSource)
                 {
                     Control = descriptor.ViewFactory.Invoke(provider),
                     ViewModel = descriptor.ViewModelFactory.Invoke(provider)
-                });
+                };
+                page.Control.DataContext = page.ViewModel;
+
+                mainViewModel.AddMainPageItem(page);
             }
 
             Log.Information("[Bootstrapper] PluginsPages completed: added {PageCount} plugin-provided UI pages into main navigation.", allDescriptors.Count);
@@ -699,12 +702,14 @@ namespace PlugHub.Bootstrap
 
             foreach (SettingsPageDescriptor descriptor in sortedDescriptors)
             {
-                ContentItemViewModel contentItem = new(descriptor.ViewType, descriptor.ViewModelType, descriptor.Name, descriptor.IconSource)
+                ContentItemViewModel page = new(descriptor.ViewType, descriptor.ViewModelType, descriptor.Name, descriptor.IconSource)
                 {
                     Control = descriptor.ViewFactory.Invoke(provider),
                     ViewModel = descriptor.ViewModelFactory.Invoke(provider)
                 };
-                settingsViewModel.AddSettingsPage(descriptor.Group, contentItem);
+                page.Control.DataContext = page.ViewModel;
+
+                settingsViewModel.AddSettingsPage(descriptor.Group, page);
             }
 
             Log.Information("[Bootstrapper] PluginsSettingPages completed: added {SettingsPageCount} plugin-provided settings pages, grouped appropriately.", allDescriptors.Count);


### PR DESCRIPTION
## Description
This change addresses an issue where plugin-provided pages and settings pages were not having their DataContext property set to their corresponding ViewModel instances. Previously, this caused UI elements in those pages to fail data binding correctly, leading to broken or missing UI updates. The fix explicitly assigns the DataContext of each page control to the ViewModel after creation, ensuring proper MVVM data binding and UI behavior in Avalonia.

## Related Issue
- Fixes #96

## Motivation and Context
Setting the DataContext explicitly on pages is essential for Avalonia's data binding framework to work as expected in the MVVM pattern. Without this, UI bindings do not resolve to the intended ViewModel, causing the user interface to be static or inconsistent with the underlying data. This fix restores expected functionality and improves plugin page integration reliability.

## How Has This Been Tested?
Manually tested by navigating to plugin pages and settings pages in the application before and after the fix. After applying the fix, UI elements correctly reflect ViewModel data, and interaction logic functions as expected. Logging verifies page registration and DataContext assignment operations.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Asset change (adds or updates icons, templates, or other assets)
- [ ] Documentation change (adds or updates documentation)
- [ ] Plugin change (adds or updates a plugin)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My change requires a change to the core logic.
  - [x] I have linked the project issue above.
- [ ] My change requires a change to the assets.
  - [ ] I have linked the asset issue above.
- [ ] My change requires a change to the documentation.
  - [ ] I have linked the documentation issue above.
- [ ] My change requires a change to a plugin.
  - [ ] I have linked the plugin issue above.
