### PR TITLE
Graceful Null Handling in SettingsViewModel

### DIFF
--- a/PlugHub/ViewModels/Pages/SettingsViewModel.cs
+++ b/PlugHub/ViewModels/Pages/SettingsViewModel.cs
@@ -26,7 +26,6 @@ namespace PlugHub.ViewModels.Pages
         [ObservableProperty]
         private ObservableCollection<string> searchSuggestions = [];
 
-
         [ObservableProperty]
         private string searchText = string.Empty;
 
@@ -37,23 +36,11 @@ namespace PlugHub.ViewModels.Pages
         private Control? selectedSettingsPageContent;
 
 
-        public SettingsViewModel(ILogger<SettingsViewModel> logger, SettingsPluginsView settingsPluginsView, SettingsPluginsViewModel settingPluginsViewModel)
+        public SettingsViewModel(ILogger<SettingsViewModel> logger, SettingsPluginsView? settingsPluginsView, SettingsPluginsViewModel? settingPluginsViewModel)
         {
             this.logger = logger;
 
-            ContentItemViewModel item = new(typeof(SettingsPluginsView), typeof(SettingsPluginsViewModel), "Plugin Editor", "plug_disconnected_regular")
-            {
-                Control = settingsPluginsView,
-                ViewModel = settingPluginsViewModel
-            };
-
-            this.SettingsPageItems.Add(new ContentItemGroupViewModel()
-            {
-                GroupName = "General Settings",
-                Items = [item]
-            });
-
-            this.OnSelectedSettingsItemChanged(item);
+            this.AddPluginSettingsPage(settingsPluginsView, settingPluginsViewModel);
 
             this.UpdateSetting();
         }
@@ -82,6 +69,36 @@ namespace PlugHub.ViewModels.Pages
             group.Items.Add(item);
 
             this.UpdateSetting();
+        }
+        private void AddPluginSettingsPage(SettingsPluginsView? settingsPluginsView, SettingsPluginsViewModel? settingPluginsViewModel)
+        {
+            if (settingsPluginsView == null)
+            {
+                this.logger.LogWarning("[SettingsViewModel] SettingsPluginsView is null. Plugin UI may not function correctly.");
+
+                return;
+            }
+
+            if (settingPluginsViewModel == null)
+            {
+                this.logger.LogWarning("[SettingsViewModel] SettingsPluginsViewModel is null. Plugin UI may not function correctly.");
+
+                return;
+            }
+
+            ContentItemViewModel item = new(typeof(SettingsPluginsView), typeof(SettingsPluginsViewModel), "Plugin Editor", "plug_disconnected_regular")
+            {
+                Control = settingsPluginsView,
+                ViewModel = settingPluginsViewModel
+            };
+
+            this.SettingsPageItems.Add(new ContentItemGroupViewModel()
+            {
+                GroupName = "General Settings",
+                Items = [item]
+            });
+
+            this.OnSelectedSettingsItemChanged(item);
         }
 
 


### PR DESCRIPTION
## Description
Modified `SettingsViewModel` to accept nullable parameters for `SettingsPluginsView` and `SettingsPluginsViewModel` plugin dependencies.  

Added null checks and appropriate logging warnings to handle cases when plugin views or viewmodels are not provided, allowing applications to run without plugins gracefully.

## Related Issue
- Resolves #99

## Motivation and Context
Not all PlugHub apps require plugin settings. Previously, the lack of plugin views or viewmodels could cause null reference exceptions or degrade user experience.  
This change makes the settings UI more robust and adaptable to plugin presence or absence.

## How Has This Been Tested?
Tested in scenarios with and without plugin settings provided.  
Verified that logging warnings appear if plugin components are missing.  
Confirmed the settings UI remains functional without plugins and correctly shows fallback behavior.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Asset change (adds or updates icons, templates, or other assets)
- [ ] Documentation change (adds or updates documentation)
- [ ] Plugin change (adds or updates a plugin)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My change requires a change to the core logic.
  - [x] I have linked the project issue above.
- [ ] My change requires a change to the assets.
  - [ ] I have linked the asset issue above.
- [ ] My change requires a change to the documentation.
  - [ ] I have linked the documentation issue above.
- [ ] My change requires a change to a plugin.
  - [ ] I have linked the plugin issue above.
