### PR TITLE
Separated Startup and Runtime Configuration Layers

### DIFF
--- a/PlugHub.Plugins/PlugHub.Plugin.Mock/PluginMock.cs
+++ b/PlugHub.Plugins/PlugHub.Plugin.Mock/PluginMock.cs
@@ -24,7 +24,7 @@ namespace PlugHub.Plugin.Mock
     /// Demonstration plugin showcasing PlugHub's multi-interface architecture.
     /// Implements branding (application identity override), configuration (token-secured configuration), and dependency injection (service provision to other plugins) simultaneously.
     /// </summary>
-    public class PluginMock : PluginBase, IPluginDependencyInjection, IPluginAppConfig, IPluginConfiguration, IPluginStyleInclusion, IPluginPages, IPluginSettingsPages
+    public class PluginMock : PluginBase, IPluginDependencyInjection, IPluginAppConfig, IPluginAppEnv, IPluginConfiguration, IPluginStyleInclusion, IPluginPages, IPluginSettingsPages
     {
         private static Token owner;
 
@@ -99,7 +99,7 @@ namespace PlugHub.Plugin.Mock
         /// Demonstrates full application rebranding — renames PlugHub to "MockHub" and overrides default paths.
         /// </summary>
         /// <remarks>
-        /// Only applies during the **system-level load phase** (global <c>PluginManifest</c>).
+        /// Only applies during the **system-level load phase**
         /// User-level plugins cannot modify <see cref="AppConfig"/>.
         /// </remarks>
         public IEnumerable<PluginAppConfigDescriptor> GetAppConfigDescriptors()
@@ -110,13 +110,36 @@ namespace PlugHub.Plugin.Mock
                     DescriptorID: Guid.Parse("f26d3290-c059-4641-8280-d229ee2c2c32"),
                     Version: Version,
                     AppConfig: (AppConfig liveAppConfig) => {
-                        liveAppConfig.AppName = "👽 MockHub 👽";
                         liveAppConfig.LoggingDirectory =
                             Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "MockHub", "Logging");
                         liveAppConfig.ConfigDirectory =
                             Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "MockHub", "Config");
-                        liveAppConfig.StorageFolderPath =
+                        liveAppConfig.StorageDirectory =
                             Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "MockHub", "Storage");
+                    },
+                    LoadBefore: [],
+                    LoadAfter: [],
+                    ConflictsWith: [],
+                    DependsOn: [])
+            ];
+        }
+
+        #endregion
+
+        #region PluginMock: IPluginAppConfig
+
+        /// <summary>
+        /// Demonstrates full application rebranding — renames PlugHub to "MockHub" and overrides default paths.
+        /// </summary>
+        public IEnumerable<PluginAppEnvDescriptor> GetAppEnvDescriptors()
+        {
+            return [
+                new PluginAppEnvDescriptor(
+                    PluginID: PluginID,
+                    DescriptorID: Guid.Parse("ba543295-88e8-474a-b370-74594dcc76a8"),
+                    Version: Version,
+                    AppEnv: (AppEnv liveAppEnv) => {
+                        liveAppEnv.AppName = "👽 MockHub 👽";
                     },
                     LoadBefore: [],
                     LoadAfter: [],

--- a/PlugHub.Shared/Attributes/DescriptorProviderAttribute.cs
+++ b/PlugHub.Shared/Attributes/DescriptorProviderAttribute.cs
@@ -1,9 +1,10 @@
 ﻿namespace PlugHub.Shared.Attributes
 {
     [AttributeUsage(AttributeTargets.Interface, Inherited = false)]
-    public sealed class DescriptorProviderAttribute(string descriptorAccessorName, bool descriptorIsOrdered = true) : Attribute
+    public sealed class DescriptorProviderAttribute(string descriptorAccessorName, bool isOrdered = true, bool isSystemOnly = false) : Attribute
     {
         public string DescriptorAccessorName { get; } = descriptorAccessorName;
-        public bool DescriptorIsOrdered { get; } = descriptorIsOrdered;
+        public bool DescriptorIsOrdered { get; } = isOrdered;
+        public bool DescriptorIsSystemOnly { get; } = isSystemOnly;
     }
 }

--- a/PlugHub.Shared/Interfaces/Plugins/IPluginAppEnv.cs
+++ b/PlugHub.Shared/Interfaces/Plugins/IPluginAppEnv.cs
@@ -5,21 +5,22 @@ using PlugHub.Shared.Models.Plugins;
 namespace PlugHub.Shared.Interfaces.Plugins
 {
     /// <summary>
-    /// Describes a plugin component that provides branding assets (such as logos, theme resources), interface-specific branding, or related metadata.
-    /// Declares all dependency and ordering relationships for conflict-free, deterministic branding integration.
+    /// Describes a plugin component that provides environment configuration settings (such as runtime options, environment-specific variables, or initialization logic).
+    /// Declares all dependency and ordering relationships for conflict-free, deterministic environment setup.
     /// </summary>
     /// <param name="PluginID">Unique identifier for the plugin providing this injector.</param>
     /// <param name="DescriptorID">Unique identifier for the descriptor.</param>
     /// <param name="Version">Version of the descriptor.</param>
+    /// <param name="AppEnv">Optional action to apply modifications to the runtime environment configuration.</param>
     /// <param name="LoadBefore">Descriptors that should be applied after this one to maintain order.</param>
     /// <param name="LoadAfter">Descriptors that should be applied before this one to maintain order.</param>
     /// <param name="DependsOn">Descriptors that this descriptor explicitly depends on.</param>
     /// <param name="ConflictsWith">Descriptors with which this descriptor cannot coexist.</param>
-    public record PluginAppConfigDescriptor(
+    public record PluginAppEnvDescriptor(
         Guid PluginID,
         Guid DescriptorID,
         string Version,
-        Action<AppConfig>? AppConfig = null,
+        Action<AppEnv>? AppEnv = null,
         IEnumerable<PluginInterfaceReference>? LoadBefore = null,
         IEnumerable<PluginInterfaceReference>? LoadAfter = null,
         IEnumerable<PluginInterfaceReference>? DependsOn = null,
@@ -27,15 +28,15 @@ namespace PlugHub.Shared.Interfaces.Plugins
             PluginDescriptor(PluginID, DescriptorID, Version, LoadBefore, LoadAfter, DependsOn, ConflictsWith);
 
     /// <summary>
-    /// Interface for plugins that supply branding assets, configuration and/or metadata.
-    /// Provides descriptors for visual, branding, and identity-related resources included with the plugin.
+    /// Interface for plugins that supply runtime environment configuration or initialization logic.
+    /// Provides descriptors for customizing application environment state, runtime behavior, and environment-specific setup included with the plugin.
     /// </summary>
-    [DescriptorProvider("GetAppConfigDescriptors", false, true)]
-    public interface IPluginAppConfig : IPlugin
+    [DescriptorProvider("GetAppEnvDescriptors", false)]
+    public interface IPluginAppEnv : IPlugin
     {
         /// <summary>
-        /// Returns a collection of descriptors defining branding elements (such as icons, logos, configuration, or theme colors) offered by this plugin.
+        /// Returns a collection of descriptors defining environment configuration and initialization steps (such as environment variables, runtime options, or configuration adjustments) offered by this plugin.
         /// </summary>
-        IEnumerable<PluginAppConfigDescriptor> GetAppConfigDescriptors();
+        IEnumerable<PluginAppEnvDescriptor> GetAppEnvDescriptors();
     }
 }

--- a/PlugHub.Shared/Interfaces/Services/Plugins/IPluginService.cs
+++ b/PlugHub.Shared/Interfaces/Services/Plugins/IPluginService.cs
@@ -1,4 +1,5 @@
-﻿using PlugHub.Shared.Models.Plugins;
+﻿using PlugHub.Shared.Attributes;
+using PlugHub.Shared.Models.Plugins;
 
 namespace PlugHub.Shared.Interfaces.Services.Plugins
 {
@@ -14,6 +15,14 @@ namespace PlugHub.Shared.Interfaces.Services.Plugins
         /// <param name="pluginDirectory">The file system directory to scan for plugin assemblies.</param>
         /// <returns>A collection of <see cref="PluginReference"/> objects representing each discovered plugin and its interfaces.</returns>
         IEnumerable<PluginReference> Discover(string pluginDirectory);
+
+        /// <summary>
+        /// Retrieves the <see cref="DescriptorProviderAttribute"/> applied to the specified interface by its full name.
+        /// Searches all loaded assemblies for the interface type and returns the attribute instance if found; otherwise, returns null.
+        /// </summary>
+        /// <param name="interfaceFullName">The full name (namespace + interface name) of the interface to inspect.</param>
+        /// <returns>The <see cref="DescriptorProviderAttribute"/> instance if found on the interface; otherwise, null.</returns>
+        DescriptorProviderAttribute? GetDescriptorProviderAttribute(string interfaceFullName);
 
         /// <summary>
         /// Loads and returns an implementation instance for a given plugin interface, cast to the specified type.

--- a/PlugHub.Shared/Models/AppConfig.cs
+++ b/PlugHub.Shared/Models/AppConfig.cs
@@ -46,12 +46,6 @@ namespace PlugHub.Shared.Models
     public sealed class AppConfig
     {
         /// <summary>
-        /// Gets or sets the display name of the application.
-        /// Used in logging, UI elements, and configuration file naming.
-        /// </summary>
-        public string? AppName { get; set; } = "PlugHub";
-
-        /// <summary>
         /// Gets or sets the root directory for all PlugHub application data.
         /// Defaults to %APPDATA%\PlugHub on Windows or equivalent on other platforms.
         /// </summary>
@@ -106,7 +100,7 @@ namespace PlugHub.Shared.Models
         /// Used by plugins and the core application for persistent data storage.
         /// Defaults to a "Storage" subdirectory within the base directory.
         /// </summary>
-        public string? StorageFolderPath { get; set; }
+        public string? StorageDirectory { get; set; }
             = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "PlugHub", "Storage");
 
         #endregion
@@ -118,7 +112,7 @@ namespace PlugHub.Shared.Models
         /// Defaults to a "Plugins" subdirectory within the application's base directory,
         /// making it suitable for portable deployments and easy plugin management.
         /// </summary>
-        public string? PluginFolderPath { get; set; }
+        public string? PluginDirectory { get; set; }
             = Path.Combine(AppContext.BaseDirectory, "Plugins");
 
         #endregion

--- a/PlugHub.Shared/Models/AppEnv.cs
+++ b/PlugHub.Shared/Models/AppEnv.cs
@@ -1,0 +1,10 @@
+namespace PlugHub.Shared.Models
+{
+    public sealed class AppEnv
+    {
+        /// <summary>
+        /// Gets or sets the display name of the application.
+        /// </summary>
+        public string? AppName { get; set; } = "PlugHub";
+    }
+}

--- a/PlugHub.UnitTests/Services/Plugins/PluginResolverTests.cs
+++ b/PlugHub.UnitTests/Services/Plugins/PluginResolverTests.cs
@@ -133,7 +133,7 @@ namespace PlugHub.UnitTests.Services.Plugins
             Guid sharedInterfaceId = Guid.NewGuid();
             Guid plugin1Id = Guid.NewGuid();
             Guid plugin2Id = Guid.NewGuid();
-            var version = "1.0.0";
+            string version = "1.0.0";
 
             // Create two descriptors with the same InterfaceID (duplicate)
             List<TestPluginDescriptor> descriptors =

--- a/PlugHub.UnitTests/Services/Plugins/PluginServiceTests.cs
+++ b/PlugHub.UnitTests/Services/Plugins/PluginServiceTests.cs
@@ -291,6 +291,51 @@ namespace PlugHub.UnitTests.Services.Plugins
 
         #endregion
 
+        #region PluginServiceTests: Descriptor Attributes
+
+        [TestMethod]
+        [TestCategory("DescriptorAttributes")]
+        public void GetDescriptorAttribute_ShouldReturnAttribute_ForValidInterface()
+        {
+            // Arrange
+            string interfaceName = "PlugHub.Shared.Interfaces.Plugins.IPluginAppConfig";
+
+            // Act
+            Shared.Attributes.DescriptorProviderAttribute? attribute = 
+                this.pluginService!.GetDescriptorProviderAttribute(interfaceName);
+
+            // Assert
+            Assert.IsNotNull(attribute, "Expected to find DescriptorAttribute on the interface.");
+            Assert.AreEqual("GetAppConfigDescriptors", attribute.DescriptorAccessorName);
+        }
+
+        [TestMethod]
+        [TestCategory("DescriptorAttributes")]
+        public void GetDescriptorAttribute_ShouldReturnNull_ForNonExistentInterface()
+        {
+            // Arrange
+            string interfaceName = "Non.Existent.Namespace.INonExistentInterface";
+
+            // Act
+            Shared.Attributes.DescriptorProviderAttribute? attribute = this.pluginService!.GetDescriptorProviderAttribute(interfaceName);
+
+            // Assert
+            Assert.IsNull(attribute, "Expected null for a non-existent interface.");
+        }
+
+        [TestMethod]
+        [TestCategory("DescriptorAttributes")]
+        public void GetDescriptorAttribute_ShouldThrow_OnNullOrEmptyInput()
+        {
+            // Arrange & Act & Assert
+            Assert.ThrowsException<ArgumentNullException>(() =>
+            {
+                this.pluginService!.GetDescriptorProviderAttribute(string.Empty);
+            });
+        }
+
+        #endregion
+
 
         private IEchoService GetEchoService(bool forceRebuild = false)
         {

--- a/PlugHub/Services/Plugins/PluginResolver.cs
+++ b/PlugHub/Services/Plugins/PluginResolver.cs
@@ -60,7 +60,7 @@ namespace PlugHub.Services.Plugins
             HashSet<TDescriptor> duplicates = [];
             HashSet<Guid> seenIDs = [];
 
-            foreach (var descriptor in descriptors)
+            foreach (TDescriptor descriptor in descriptors)
             {
                 if (seenIDs.Add(descriptor.DescriptorID))
                     cleanDescriptors.Add(descriptor);

--- a/PlugHub/Services/Plugins/PluginService.cs
+++ b/PlugHub/Services/Plugins/PluginService.cs
@@ -24,7 +24,7 @@ namespace PlugHub.Services.Plugins
             this.logger = logger;
         }
 
-        #region PlugHub.Services.PluginService Plugin Instances
+        #region PluginService: Plugin Instances
 
         public TPlugin? GetLoadedPlugin<TPlugin>(PluginInterface pluginInterface) where TPlugin : PluginBase
         {
@@ -98,7 +98,38 @@ namespace PlugHub.Services.Plugins
 
         #endregion
 
-        #region PlugHub.Services.PluginService: Discovery
+        #region PluginService: Plugin Interface Data
+
+        public DescriptorProviderAttribute? GetDescriptorProviderAttribute(string interfaceFullName)
+        {
+            if (string.IsNullOrWhiteSpace(interfaceFullName))
+                throw new ArgumentNullException(nameof(interfaceFullName));
+
+            foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                Type? interfaceType = null;
+
+                try
+                {
+                    interfaceType = assembly.GetType(interfaceFullName, throwOnError: false, ignoreCase: false);
+                }
+                catch { /* nothing to see here */ }
+
+                if (interfaceType != null && interfaceType.IsInterface)
+                {
+                    DescriptorProviderAttribute? attr = 
+                        interfaceType.GetCustomAttribute<DescriptorProviderAttribute>(inherit: false);
+
+                    if (attr != null) return attr;
+                }
+            }
+
+            return null;
+        }
+
+        #endregion
+
+        #region PluginService: Discovery
 
         public IEnumerable<PluginReference> Discover(string pluginDirectory)
         {

--- a/PlugHub/ViewModels/Pages/SettingsPluginsViewModel.cs
+++ b/PlugHub/ViewModels/Pages/SettingsPluginsViewModel.cs
@@ -247,13 +247,13 @@ namespace PlugHub.ViewModels.Pages
             this.isUpdating = true;
             this.isPluginCheckboxUpdating = true;
 
-            bool hasDefault = plugin.ProvidedDescriptors.Any(i => i.IsSystem);
             bool isIndeterminate = plugin.IsEnabled == null;
 
             if (isIndeterminate == false)
             {
                 foreach (PluginDescriptorViewModel ifaceVm in plugin.ProvidedDescriptors)
-                    ifaceVm.IsEnabled = true;
+                    if (!ifaceVm.IsSystem)
+                        ifaceVm.IsEnabled = true;
 
                 this.pluginRegistrar.SetAllEnabled(plugin.PluginID, enabled: true);
 
@@ -262,9 +262,8 @@ namespace PlugHub.ViewModels.Pages
             else
             {
                 foreach (PluginDescriptorViewModel ifaceVm in plugin.ProvidedDescriptors)
-                {
-                    ifaceVm.IsEnabled = ifaceVm.IsSystem;
-                }
+                    if (!ifaceVm.IsSystem)
+                        ifaceVm.IsEnabled = false;
 
                 this.pluginRegistrar.SetAllEnabled(plugin.PluginID, enabled: false);
 
@@ -276,7 +275,9 @@ namespace PlugHub.ViewModels.Pages
                     this.pluginRegistrar.SetEnabled(plugin.PluginID, interfaceType, enabled: true);
                 }
 
-                plugin.IsEnabled = hasDefault ? null : false;
+                bool anyEnabled = plugin.ProvidedDescriptors.Any(i => i.IsEnabled);
+
+                plugin.IsEnabled = anyEnabled ? null : false;
             }
 
             this.UpdateShowRestartBanner();

--- a/PlugHub/Views/Pages/SettingsPluginsView.axaml
+++ b/PlugHub/Views/Pages/SettingsPluginsView.axaml
@@ -563,7 +563,7 @@
 
         </StackPanel>
 
-        <!-- List Section fills remaining space -->
+        <!-- Interface DataGrid -->
         <DataGrid Grid.Row="1"
                   Margin="0,8,0,0"
                   Name="TargetDataGrid"
@@ -575,6 +575,7 @@
                   BorderThickness="1"
                   BorderBrush="Gray"
                   CornerRadius="4">
+
           <DataGrid.Columns>
             <DataGridTemplateColumn Header="Plugin" Width="4*">
               <DataGridTemplateColumn.CellTemplate>
@@ -591,9 +592,10 @@
               </DataGridTemplateColumn.CellTemplate>
             </DataGridTemplateColumn>
           </DataGrid.Columns>
+
         </DataGrid>
 
-        <!-- Metadata panel below DataGrid in same Grid (Grid.Row=2 or below) -->
+        <!-- Interface Details Panel -->
         <HeaderedContentControl Grid.Row="2"
                                 Classes="GroupBox"
                                 Header="Descriptor Details"


### PR DESCRIPTION
## Description
This PR implements a clear separation between the startup bootstrap configuration (`AppConfig`) and the mutable runtime environment state (`AppEnv`). `AppConfig` is now the authoritative immutable startup configuration owned exclusively by system-level plugins, ensuring consistent and corruption-free bootstrap behavior. `AppEnv` holds mutable runtime values such as app name, theme, and culture that can be safely adjusted post-startup by user-level plugins.

Key changes include:
- Introduction of the `AppEnv` model alongside `AppConfig`.
- Extension of plugin interface descriptor attributes with a `SystemOnly` flag to designate system-owned interfaces and enforce mutation restrictions.
- Updated bootstrapper to load, finalize, and manage `AppConfig` and `AppEnv` separately with appropriate plugin policy enforcement.
- Plugin discovery, registration, and UI updated to distinguish system-owned vs user-mutable plugin interfaces.
- Added `PluginMock` demonstration plugin illustrating multi-interface design and application rebranding using the new config layering.

## Related Issue
- Resolves #91

## Motivation and Context
The previous design combined startup bootstrap configuration and runtime mutable state within `AppConfig`, leading to state corruption and confusing plugin behavior. This change provides strong guarantees of startup config stability while enabling safe runtime mutability, simplifying user experience and developer contracts.

## How Has This Been Tested?
- Unit tests updated and added covering new `SystemOnly` attribute behavior, plugin discovery, and config layering enforcement.
- Manual testing of application startup, plugin loading, branding, and runtime configuration mutation verified.
- Logging observed for correct application of system and user plugin config mutations.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Asset change (adds or updates icons, templates, or other assets)
- [ ] Documentation change (adds or updates documentation)
- [x] Plugin change (adds or updates a plugin)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My change requires a change to the core logic.
  - [x] I have linked the project issue above.
- [ ] My change requires a change to the assets.
  - [ ] I have linked the asset issue above.
- [ ] My change requires a change to the documentation.
  - [ ] I have linked the documentation issue above.
- [x] My change requires a change to a plugin.
  - [x] I have linked the plugin issue above.
