### PR TITLE
Replaced dependency injector instance with factory

### DIFF
--- a/PlugHub.Shared/Interfaces/Plugins/IPluginDependencyInjection.cs
+++ b/PlugHub.Shared/Interfaces/Plugins/IPluginDependencyInjection.cs
@@ -14,7 +14,7 @@ namespace PlugHub.Shared.Interfaces.Plugins
     /// <param name="Version">Version of the descriptor.</param>
     /// <param name="InterfaceType">The interface type to be injected.</param>
     /// <param name="ImplementationType">Optional explicit implementation type; if null, Instance is used.</param>
-    /// <param name="Instance">Optional singleton instance to provide if implementation type is not specified.</param>
+    /// <param name="ImplementationFactory">Optional factory delegate to create your service with full DI support.</param>
     /// <param name="Lifetime">Registration lifetime (singleton, scoped, transient) for this injector.</param>
     /// <param name="LoadBefore">Descriptors that should be applied after this one to maintain order.</param>
     /// <param name="LoadAfter">Descriptors that should be applied before this one to maintain order.</param>
@@ -26,7 +26,7 @@ namespace PlugHub.Shared.Interfaces.Plugins
         string Version,
         Type InterfaceType,
         Type? ImplementationType = null,
-        object? Instance = null,
+        Func<IServiceProvider, object?>? ImplementationFactory = null,
         ServiceLifetime Lifetime = ServiceLifetime.Singleton,
         IEnumerable<PluginInterfaceReference>? LoadBefore = null,
         IEnumerable<PluginInterfaceReference>? LoadAfter = null,

--- a/PlugHub.UnitTests/Services/Plugins/PluginServiceTests.cs
+++ b/PlugHub.UnitTests/Services/Plugins/PluginServiceTests.cs
@@ -368,11 +368,13 @@ namespace PlugHub.UnitTests.Services.Plugins
                                 descriptor.ImplementationType,
                                 descriptor.Lifetime));
                     }
-                    else if (descriptor.Instance != null)
+                    else if (descriptor.ImplementationFactory != null)
                     {
-                        this.serviceCollection.AddSingleton(
-                            descriptor.InterfaceType,
-                            descriptor.Instance);
+                        this.serviceCollection.Add(
+                            new ServiceDescriptor(
+                                descriptor.InterfaceType,
+                                provider => descriptor.ImplementationFactory(provider)!,
+                                descriptor.Lifetime));
                     }
                 }
 


### PR DESCRIPTION
## Description  
This change removes the direct singleton instance registration from `PluginInjectorDescriptor` and introduces an optional factory delegate of type `Func<IServiceProvider, object?>` for deferred and flexible instance creation. The factory delegate allows full utilization of the DI container during service construction, simplifying plugin registration and improving maintainability. The existing support for specifying implementation types is preserved, enabling automatic DI resolution when possible. Plugin bootstrapper logic is updated to use the factory delegate if provided, with fallback to implementation types.  

## Related Issue  
- Resolves #112

## Motivation and Context  
Direct instance registration requires manual construction of all dependencies, causing boilerplate and limiting flexibility in complex plugin scenarios. Switching to a factory delegate aligns with Microsoft.Extensions.DependencyInjection patterns, reduces cognitive load, and enhances plugin robustness by leveraging the full DI container for instance creation.

## How Has This Been Tested?  
Updates were tested by modifying unit tests in `PluginServiceTests` to cover registrations using the new factory delegate approach. Tests ensure correct service collection setup and behavior consistent with the prior instance registration model but with added flexibility.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Asset change (adds or updates icons, templates, or other assets)
- [ ] Documentation change (adds or updates documentation)
- [ ] Plugin change (adds or updates a plugin)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My change requires a change to the core logic.
  - [x] I have linked the project issue above.
- [ ] My change requires a change to the assets.
  - [ ] I have linked the asset issue above.
- [ ] My change requires a change to the documentation.
  - [ ] I have linked the documentation issue above.
- [ ] My change requires a change to a plugin.
  - [ ] I have linked the plugin issue above.
