### PR TITLE
Add SortContext handling and UI indicators

### DIFF
--- a/PlugHub.Shared/Attributes/DescriptorProviderAttribute.cs
+++ b/PlugHub.Shared/Attributes/DescriptorProviderAttribute.cs
@@ -1,10 +1,17 @@
 ﻿namespace PlugHub.Shared.Attributes
 {
+    public enum DescriptorSortContext
+    {
+        None = 0,
+        Forward = 1,
+        Reverse = 2,
+    }
+
     [AttributeUsage(AttributeTargets.Interface, Inherited = false)]
-    public sealed class DescriptorProviderAttribute(string descriptorAccessorName, bool isOrdered = true, bool isSystemOnly = false) : Attribute
+    public sealed class DescriptorProviderAttribute(string descriptorAccessorName, bool isSystemOnly = false, DescriptorSortContext sortContext = DescriptorSortContext.Reverse) : Attribute
     {
         public string DescriptorAccessorName { get; } = descriptorAccessorName;
-        public bool DescriptorIsOrdered { get; } = isOrdered;
         public bool DescriptorIsSystemOnly { get; } = isSystemOnly;
+        public DescriptorSortContext SortContext { get; } = sortContext;
     }
 }

--- a/PlugHub.Shared/Interfaces/Plugins/IPluginAppConfig.cs
+++ b/PlugHub.Shared/Interfaces/Plugins/IPluginAppConfig.cs
@@ -30,7 +30,7 @@ namespace PlugHub.Shared.Interfaces.Plugins
     /// Interface for plugins that supply branding assets, configuration and/or metadata.
     /// Provides descriptors for visual, branding, and identity-related resources included with the plugin.
     /// </summary>
-    [DescriptorProvider("GetAppConfigDescriptors", false, true)]
+    [DescriptorProvider("GetAppConfigDescriptors", true)]
     public interface IPluginAppConfig : IPlugin
     {
         /// <summary>

--- a/PlugHub.Shared/Interfaces/Plugins/IPluginAppEnv.cs
+++ b/PlugHub.Shared/Interfaces/Plugins/IPluginAppEnv.cs
@@ -31,7 +31,7 @@ namespace PlugHub.Shared.Interfaces.Plugins
     /// Interface for plugins that supply runtime environment configuration or initialization logic.
     /// Provides descriptors for customizing application environment state, runtime behavior, and environment-specific setup included with the plugin.
     /// </summary>
-    [DescriptorProvider("GetAppEnvDescriptors", false)]
+    [DescriptorProvider("GetAppEnvDescriptors")]
     public interface IPluginAppEnv : IPlugin
     {
         /// <summary>


### PR DESCRIPTION
## Description
This PR introduces the new `DescriptorSortContext` enum (`None`, `Forward`, `Reverse`) and updates `DescriptorProviderAttribute` to use it instead of the previous `isOrdered` flag.  

The `SettingsPluginsViewModel` has been updated to surface sort context in the UI with clear icons and messages, including highlighting the primary descriptor even in unordered contexts.  

Interfaces such as `IPluginAppConfig` and `IPluginAppEnv` have been updated to use the new attribute signature.  

## Related Issue
- Resolves #114

## Motivation and Context
This change removes ambiguity around descriptor ordering by making sort context explicit and visible.  

It improves developer clarity, aligns with DI best practices (last-applied-wins as the default), and provides consistent UI feedback for plugin authors and host developers.  

## How Has This Been Tested?
- Verified changes compile and run successfully.  
- Performed manual testing of plugin UI to confirm correct icons and messages are displayed for each `SortContext`.  
- Confirmed no regressions in existing backend unit tests.  
- Avalonia UI testing is not yet automated, but manual checks confirm expected behavior.  

## Screenshots (if appropriate):
N/A

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)  
- [x] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to change)  
- [ ] Asset change (adds or updates icons, templates, or other assets)  
- [ ] Documentation change (adds or updates documentation)  
- [ ] Plugin change (adds or updates a plugin)  

## Checklist:
- [x] I have read the **CONTRIBUTING** document.  
- [x] My change requires a change to the core logic.  
  - [x] I have linked the project issue above.  
- [ ] My change requires a change to the assets.  
  - [ ] I have linked the asset issue above.  
- [ ] My change requires a change to the documentation.  
  - [ ] I have linked the documentation issue above.  
- [ ] My change requires a change to a plugin.  
  - [ ] I have linked the plugin issue above.  