### PR TITLE
Centralize descriptor ordering in IPluginResolver

### DIFF
--- a/PlugHub.Plugins/Diagnostics/PlugHub.Plugin.Mock/Services/EchoService.cs
+++ b/PlugHub.Plugins/Diagnostics/PlugHub.Plugin.Mock/Services/EchoService.cs
@@ -59,21 +59,11 @@ namespace PlugHub.Plugin.Mock.Services
             return message;
         }
 
-
         private static IEnumerable<EchoResultDescriptor> PluginsConfigs(IPluginResolver resolver, IEnumerable<IEchoResultHandler> resultHandlers)
         {
             ArgumentNullException.ThrowIfNull(resultHandlers);
 
-            List<EchoResultDescriptor> allDescriptors = [];
-
-            foreach (IEchoResultHandler resultHandler in resultHandlers)
-            {
-                IEnumerable<EchoResultDescriptor> descriptors = resultHandler.GetEchoResultDescriptors();
-
-                allDescriptors.AddRange(descriptors);
-            }
-
-            return resolver.ResolveDescriptors(allDescriptors);
+            return resolver.ResolveAndOrder<IEchoResultHandler, EchoResultDescriptor>(resultHandlers);
         }
     }
 }

--- a/PlugHub.Plugins/Diagnostics/PlugHub.Shared.Mock/Interfaces/Plugins/IEchoResultHandler .cs
+++ b/PlugHub.Plugins/Diagnostics/PlugHub.Shared.Mock/Interfaces/Plugins/IEchoResultHandler .cs
@@ -1,4 +1,5 @@
-﻿using PlugHub.Shared.Interfaces.Plugins;
+﻿using PlugHub.Shared.Attributes;
+using PlugHub.Shared.Interfaces.Plugins;
 using PlugHub.Shared.Mock.Interfaces.Services;
 using PlugHub.Shared.Models.Plugins;
 
@@ -24,6 +25,7 @@ namespace PlugHub.Shared.Mock.Interfaces.Plugins
     /// Plugin-level handler invoked on both successful echo and echo error.
     /// Supports extensibility of EchoService behavior by contributing a combined success/error processing pipeline.
     /// </summary>
+    [DescriptorProvider("GetEchoResultDescriptors")]
     public interface IEchoResultHandler : IPlugin
     {
         /// <summary>

--- a/PlugHub.Shared/Interfaces/Services/Plugins/IPluginResolver.cs
+++ b/PlugHub.Shared/Interfaces/Services/Plugins/IPluginResolver.cs
@@ -11,21 +11,26 @@ namespace PlugHub.Shared.Interfaces.Services.Plugins
     public interface IPluginResolver
     {
         /// <summary>
+        /// Resolves descriptors for the given plugin interface type by:<br/>
+        /// 1. Using the interface’s <see cref="DescriptorProviderAttribute"/> to locate the descriptor accessor.<br/>
+        /// 2. Invoking the accessor on each provided plugin instance to collect descriptors.<br/>
+        /// 3. Performing dependency resolution and topological sort.<br/>
+        /// 4. Applying the interface’s declared <see cref="DescriptorSortContext"/>.
+        /// </summary>
+        /// <typeparam name="TInterface">The plugin interface type annotated with <see cref="DescriptorProviderAttribute"/>.</typeparam>
+        /// <typeparam name="TDescriptor">The descriptor type returned by the accessor; must inherit from <see cref="PluginDescriptor"/>.</typeparam>
+        /// <param name="plugins">The plugin instances implementing <typeparamref name="TInterface"/>.</param>
+        /// <returns>A deterministic, dependency-valid, conflict-free, and correctly ordered sequence of descriptors.</returns>
+        IReadOnlyList<TDescriptor> ResolveAndOrder<TInterface, TDescriptor>(IEnumerable<TInterface> plugins) where TInterface : class where TDescriptor : PluginDescriptor;
+
+        /// <summary>
         /// Builds a full resolution context for the given set of plugin descriptors,
         /// preserving both valid order information and any rejection reasons.  
         /// </summary>
-        /// <typeparam name="TDescriptor">
-        /// The interface descriptor type being resolved; must inherit from <see cref="PluginDescriptor"/>.
-        /// </typeparam>
-        /// <param name="descriptors">
-        /// The collection of interface descriptors to evaluate for ordering and conflicts.
-        /// </param>
-        /// <returns>
-        /// A <see cref="PluginResolutionContext{TDescriptor}"/> containing deterministic
-        /// ordering results along with detailed state about rejected or disabled descriptors.
-        /// </returns>
-        PluginResolutionContext<TDescriptor> ResolveContext<TDescriptor>(IEnumerable<TDescriptor> descriptors)
-            where TDescriptor : PluginDescriptor;
+        /// <typeparam name="TDescriptor">The interface descriptor type being resolved; must inherit from <see cref="PluginDescriptor"/>.</typeparam>
+        /// <param name="descriptors">The collection of interface descriptors to evaluate for ordering and conflicts.</param>
+        /// <returns>A <see cref="PluginResolutionContext{TDescriptor}"/> containing deterministic ordering results along with detailed state about rejected or disabled descriptors.</returns>
+        PluginResolutionContext<TDescriptor> ResolveContext<TDescriptor>(IEnumerable<TDescriptor> descriptors) where TDescriptor : PluginDescriptor;
 
         /// <summary>
         /// Returns a dependency- and conflict-aware, stable ordering of interface descriptors.
@@ -34,16 +39,9 @@ namespace PlugHub.Shared.Interfaces.Services.Plugins
         /// descriptors are filtered out. The resulting list preserves the same order on every run for the
         /// same input, ensuring predictability and safe plugin initialization.
         /// </summary>
-        /// <typeparam name="TDescriptor">
-        /// The interface descriptor type being resolved and ordered; must inherit from <see cref="PluginDescriptor"/>.
-        /// </typeparam>
-        /// <param name="descriptors">
-        /// The collection of interface descriptors to process and order.
-        /// </param>
-        /// <returns>
-        /// A deterministic, dependency-valid, and conflict-free sequence of interface descriptors, sorted for correct load.
-        /// </returns>
-        IEnumerable<TDescriptor> ResolveDescriptors<TDescriptor>(IEnumerable<TDescriptor> descriptors)
-            where TDescriptor : PluginDescriptor;
+        /// <typeparam name="TDescriptor">The interface descriptor type being resolved and ordered; must inherit from <see cref="PluginDescriptor"/>.</typeparam>
+        /// <param name="descriptors">The collection of interface descriptors to process and order.</param>
+        /// <returns>A deterministic, dependency-valid, and conflict-free sequence of interface descriptors, sorted for correct load.</returns>
+        IEnumerable<TDescriptor> ResolveDescriptors<TDescriptor>(IEnumerable<TDescriptor> descriptors) where TDescriptor : PluginDescriptor;
     }
 }


### PR DESCRIPTION


## Description
This change removes manual descriptor gathering and sorting logic from multiple bootstrapper methods (`PluginsConfigs`, `PluginsStyleInclude`, `PluginsPages`, `PluginsSettingPages`, `PluginAppServices`, etc.).  
Instead, all now use the new `ResolveAndOrder<TInterface, TDescriptor>` API, which centralizes descriptor discovery and ordering.  
This reduces boilerplate, ensures consistent application of `SortContext`, and makes the bootstrapper methods easier to read and maintain.

## Related Issue
- Resolves #120

## Motivation and Context
Previously, each bootstrapper method duplicated logic to gather descriptors, sort them, and apply ordering.  
This was error‑prone and inconsistent. By consolidating this into the resolver, we ensure correctness, reduce code duplication, and make future maintenance easier.

## How Has This Been Tested?
- All existing unit tests continue to pass.  
- Added new unit tests specifically for `ResolveAndOrder` to verify `Forward` and `Reverse` `SortContext` behavior.  
- Verified integration tests for plugin loading, style includes, pages, and settings pages still succeed.  
- Manual run of the application confirmed plugins load and apply correctly.

## Screenshots (if appropriate):
N/A

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)  
- [x] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to change)  
- [ ] Asset change (adds or updates icons, templates, or other assets)  
- [ ] Documentation change (adds or updates documentation)  
- [ ] Plugin change (adds or updates a plugin)  

## Checklist:
- [x] I have read the **CONTRIBUTING** document.  
- [x] My change requires a change to the core logic.  
  - [x] I have linked the project issue above.  
- [ ] My change requires a change to the assets.  
  - [ ] I have linked the asset issue above.  
- [ ] My change requires a change to the documentation.  
  - [ ] I have linked the documentation issue above.  
- [ ] My change requires a change to a plugin.  
  - [ ] I have linked the plugin issue above.  