### PR TITLE
Add optional factory delegate support to `IPluginStyleInclusion`

### DIFF
--- a/PlugHub.Plugins/Diagnostics/PlugHub.Plugin.Mock/PluginMock.cs
+++ b/PlugHub.Plugins/Diagnostics/PlugHub.Plugin.Mock/PluginMock.cs
@@ -225,12 +225,11 @@ namespace PlugHub.Plugin.Mock
                     DescriptorID: Guid.Parse("f9e88050-b8c3-43b3-b76e-79f16595acff"),
                     Version: Version,
                     "avares://PlugHub.Plugin.Mock/Styles/Icons.axaml",
-                    null,
                     LoadBefore: [],
                     LoadAfter: [],
                     ConflictsWith: [],
                     DependsOn: []
-                )
+                ),
             ];
         }
 

--- a/PlugHub.Shared/Interfaces/Plugins/IPluginStyleInclusion.cs
+++ b/PlugHub.Shared/Interfaces/Plugins/IPluginStyleInclusion.cs
@@ -1,4 +1,5 @@
-﻿using PlugHub.Shared.Attributes;
+﻿using Avalonia.Styling;
+using PlugHub.Shared.Attributes;
 using PlugHub.Shared.Models.Plugins;
 
 
@@ -14,6 +15,7 @@ namespace PlugHub.Shared.Interfaces.Plugins
     /// <param name="Version">Version of the descriptor.</param>
     /// <param name="ResourceUri">URI of the AXAML resource to be loaded as a StyleInclude.</param>
     /// <param name="BaseUri">Base URI for resolving relative resource paths (defaults to plugin's base URI).</param>
+    /// <param name="Factory">Optional delegate that creates one or more <see cref="IStyle"/> instances at runtime.</param>
     /// <param name="LoadBefore">Descriptors that should be applied after this one to maintain order.</param>
     /// <param name="LoadAfter">Descriptors that should be applied before this one to maintain order.</param>
     /// <param name="DependsOn">Descriptors that this descriptor explicitly depends on.</param>
@@ -22,13 +24,14 @@ namespace PlugHub.Shared.Interfaces.Plugins
         Guid PluginID,
         Guid DescriptorID,
         string Version,
-        string ResourceUri,
+        string? ResourceUri = null,
         string? BaseUri = null,
+        Func<IStyle>? Factory = null,
         IEnumerable<PluginDescriptorReference>? LoadBefore = null,
         IEnumerable<PluginDescriptorReference>? LoadAfter = null,
         IEnumerable<PluginDescriptorReference>? DependsOn = null,
-        IEnumerable<PluginDescriptorReference>? ConflictsWith = null) :
-            PluginDescriptor(PluginID, DescriptorID, Version, LoadBefore, LoadAfter, DependsOn, ConflictsWith);
+        IEnumerable<PluginDescriptorReference>? ConflictsWith = null
+    ) : PluginDescriptor(PluginID, DescriptorID, Version, LoadBefore, LoadAfter, DependsOn, ConflictsWith);
 
     /// <summary>
     /// Interface for plugins that supply Avalonia StyleInclude resources.


### PR DESCRIPTION
## Description
This change extends `PluginStyleIncludeDescriptor` with an optional `Func<IStyle>` factory.  

The bootstrapper has been updated to handle both:
- URI‑based `StyleInclude` resources (existing behavior, unchanged).
- Factory‑produced styles (new behavior).

Factory styles are deduplicated by type to prevent multiple injections of the same theme.  

This enables scenarios like shipping FluentAvalonia 2 (FA2) as a plugin rather than hard‑coding it in the host application.

## Related Issue
- Resolves #117

## Motivation and Context
Previously, only XAML resources could be included via `ResourceUri`.  
Some libraries (e.g. FA2) require programmatic initialization.  
Adding a factory delegate allows plugins to contribute styles and themes that cannot be expressed as static XAML includes.  
This keeps the host app lean and makes theming pluggable.

## How Has This Been Tested?
- Verified with a mock plugin that injects a simple `TextBlock` style via factory (all text turned red as expected).
- Verified with a mock plugin that injects a `FluentAvaloniaTheme` via factory (theme applied successfully).
- Confirmed that existing URI‑based includes continue to load without change.

## Screenshots (if appropriate):
N/A

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Asset change (adds or updates icons, templates, or other assets)
- [ ] Documentation change (adds or updates documentation)
- [ ] Plugin change (adds or updates a plugin)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My change requires a change to the core logic.
  - [x] I have linked the project issue above.
- [ ] My change requires a change to the assets.
  - [ ] I have linked the asset issue above.
- [ ] My change requires a change to the documentation.
  - [ ] I have linked the documentation issue above.
- [ ] My change requires a change to a plugin.
  - [ ] I have linked the plugin issue above.