### PR TITLE
Implemented `IPluginMainView` for pluggable main view support 

### DIFF
--- a/PlugHub.Shared/Interfaces/Plugins/IPluginMainView.cs
+++ b/PlugHub.Shared/Interfaces/Plugins/IPluginMainView.cs
@@ -1,0 +1,52 @@
+﻿using Avalonia.Controls;
+using PlugHub.Shared.Attributes;
+using PlugHub.Shared.Models.Plugins;
+using PlugHub.Shared.ViewModels;
+
+namespace PlugHub.Shared.Interfaces.Plugins
+{
+    /// <summary>
+    /// Descriptor for a plugin-provided main view.
+    /// Defines the view, view model, and optional factories,
+    /// along with dependency, conflict, and ordering metadata.
+    /// </summary>
+    /// <param name="PluginID">Unique identifier of the plugin providing this descriptor.</param>
+    /// <param name="DescriptorID">Unique identifier of this descriptor.</param>
+    /// <param name="Version">Version string of the descriptor.</param>
+    /// <param name="Key">Identifier for this main view; combined with its ViewType to form a unique config key.</param>
+    /// <param name="ViewType">Concrete Avalonia <see cref="UserControl"/> type for the view.</param>
+    /// <param name="ViewModelType">Associated <see cref="BaseViewModel"/> type for the view.</param>
+    /// <param name="ViewFactory">Optional factory to create the view instance.</param>
+    /// <param name="ViewModelFactory">Optional factory to create the view model instance.</param>
+    /// <param name="LoadBefore">Descriptors that should load after this one.</param>
+    /// <param name="LoadAfter">Descriptors that should load before this one.</param>
+    /// <param name="DependsOn">Descriptors this one depends on.</param>
+    /// <param name="ConflictsWith">Descriptors that cannot coexist with this one.</param>
+    public record PluginMainViewDescriptor(
+        Guid PluginID,
+        Guid DescriptorID,
+        string Version,
+        string Key,
+        Type ViewType,
+        Type ViewModelType,
+        Func<IServiceProvider, UserControl>? ViewFactory = null,
+        Func<IServiceProvider, BaseViewModel>? ViewModelFactory = null,
+        IEnumerable<PluginDescriptorReference>? LoadBefore = null,
+        IEnumerable<PluginDescriptorReference>? LoadAfter = null,
+        IEnumerable<PluginDescriptorReference>? DependsOn = null,
+        IEnumerable<PluginDescriptorReference>? ConflictsWith = null
+    ) : PluginDescriptor(PluginID, DescriptorID, Version, LoadBefore, LoadAfter, DependsOn, ConflictsWith);
+
+    /// <summary>
+    /// Contract for plugins that contribute main views (top-level pages) to the host.
+    /// Provides descriptors describing the plugin's views and related metadata.
+    /// </summary>
+    [DescriptorProvider("GetMainViewDescriptors", false)]
+    public interface IPluginMainView : IPlugin
+    {
+        /// <summary>
+        /// Returns descriptors for the main views provided by this plugin.
+        /// </summary>
+        IEnumerable<PluginPageDescriptor> GetMainViewDescriptors();
+    }
+}

--- a/PlugHub.Shared/Interfaces/Plugins/IPluginPages.cs
+++ b/PlugHub.Shared/Interfaces/Plugins/IPluginPages.cs
@@ -1,5 +1,7 @@
 ﻿using Avalonia.Controls;
+using Microsoft.Extensions.DependencyInjection;
 using PlugHub.Shared.Attributes;
+using PlugHub.Shared.Interfaces.Services.Plugins;
 using PlugHub.Shared.Models.Plugins;
 using PlugHub.Shared.ViewModels;
 
@@ -39,8 +41,72 @@ namespace PlugHub.Shared.Interfaces.Plugins
             IEnumerable<PluginDescriptorReference>? LoadBefore = null,
             IEnumerable<PluginDescriptorReference>? LoadAfter = null,
             IEnumerable<PluginDescriptorReference>? DependsOn = null,
-            IEnumerable<PluginDescriptorReference>? ConflictsWith = null) :
-                PluginDescriptor(PluginID, DescriptorID, Version, LoadBefore, LoadAfter, DependsOn, ConflictsWith);
+            IEnumerable<PluginDescriptorReference>? ConflictsWith = null) : PluginDescriptor(PluginID, DescriptorID, Version, LoadBefore, LoadAfter, DependsOn, ConflictsWith)
+    {
+        /// <summary>
+        /// Creates a <see cref="ContentItemViewModel"/> instance from the given <see cref="PluginPageDescriptor"/> using the provided <see cref="IServiceProvider"/>.
+        /// </summary>
+        /// <param name="provider">The service provider used to resolve the view, view model, and any dependencies.</param>
+        /// <param name="descriptor">The descriptor containing type and factory information for the page.</param>
+        /// <returns>
+        /// A fully constructed <see cref="ContentItemViewModel"/> with its <see cref="Controls.UserControl"/> and <see cref="BaseViewModel"/> instantiated and bound together, or <c>null</c> if either cannot be resolved.
+        /// </returns>
+        public static ContentItemViewModel? GetItemViewModel(IServiceProvider provider, PluginPageDescriptor descriptor)
+        {
+            ArgumentNullException.ThrowIfNull(provider);
+            ArgumentNullException.ThrowIfNull(descriptor);
+
+            IPluginResolver pluginResolver = provider.GetRequiredService<IPluginResolver>();
+            IEnumerable<IPluginPages> pageProviders = provider.GetServices<IPluginPages>();
+
+            IReadOnlyList<PluginPageDescriptor> orderedDescriptors =
+                pluginResolver.ResolveAndOrder<IPluginPages, PluginPageDescriptor>(pageProviders);
+
+            UserControl? view;
+            BaseViewModel? viewModel;
+
+            #region PluginsPages: Resolve View
+
+            if (descriptor.ViewFactory != null)
+            {
+                view = descriptor.ViewFactory(provider);
+            }
+            else if (descriptor.ViewType != null)
+            {
+                view = provider.GetService(descriptor.ViewType) as UserControl;
+
+                if (view is null) return null;
+            }
+            else return null;
+
+            #endregion
+
+            #region PluginPages: Resolve ViewModel
+
+            if (descriptor.ViewModelFactory != null)
+            {
+                viewModel = descriptor.ViewModelFactory(provider);
+            }
+            else if (descriptor.ViewModelType != null)
+            {
+                viewModel = provider.GetService(descriptor.ViewModelType) as BaseViewModel;
+
+                if (viewModel is null) return null;
+            }
+            else return null;
+
+            #endregion
+
+            ContentItemViewModel item = new(descriptor.ViewType!, descriptor.ViewModelType!, descriptor.Name, descriptor.IconSource)
+            {
+                Control = view,
+                ViewModel = viewModel
+            };
+            view.DataContext = viewModel;
+
+            return item;
+        }
+    }
 
     /// <summary>
     /// Interface for plugins that provide pages to the host application.

--- a/PlugHub.Shared/Interfaces/Plugins/IPluginSettingsPages.cs
+++ b/PlugHub.Shared/Interfaces/Plugins/IPluginSettingsPages.cs
@@ -1,5 +1,7 @@
 ﻿using Avalonia.Controls;
+using Microsoft.Extensions.DependencyInjection;
 using PlugHub.Shared.Attributes;
+using PlugHub.Shared.Interfaces.Services.Plugins;
 using PlugHub.Shared.Models.Plugins;
 using PlugHub.Shared.ViewModels;
 
@@ -38,8 +40,25 @@ namespace PlugHub.Shared.Interfaces.Plugins
         IEnumerable<PluginDescriptorReference>? LoadBefore = null,
         IEnumerable<PluginDescriptorReference>? LoadAfter = null,
         IEnumerable<PluginDescriptorReference>? DependsOn = null,
-        IEnumerable<PluginDescriptorReference>? ConflictsWith = null) :
-            PluginPageDescriptor(PluginID, DescriptorID, Version, ViewType, ViewModelType, Name, IconSource, ViewFactory, ViewModelFactory, LoadBefore, LoadAfter, DependsOn, ConflictsWith);
+        IEnumerable<PluginDescriptorReference>? ConflictsWith = null) : PluginPageDescriptor(PluginID, DescriptorID, Version, ViewType, ViewModelType, Name, IconSource, ViewFactory, ViewModelFactory, LoadBefore, LoadAfter, DependsOn, ConflictsWith)
+    {
+        /// <summary>
+        /// Creates a <see cref="ContentItemViewModel"/> from the specified
+        /// <see cref="SettingsPageDescriptor"/> using the provided <see cref="IServiceProvider"/>.
+        /// </summary>
+        /// <param name="provider">The service provider used to resolve the view, view model, and their dependencies.</param>
+        /// <param name="descriptor">The descriptor containing type and factory information for the settings page.</param>
+        /// <returns>
+        /// A fully constructed <see cref="ContentItemViewModel"/> with its view and view model instantiated and bound, or <c>null</c> if either cannot be resolved.
+        /// </returns>
+        public static ContentItemViewModel? GetItemViewModel(IServiceProvider provider, SettingsPageDescriptor descriptor)
+        {
+            ArgumentNullException.ThrowIfNull(provider);
+            ArgumentNullException.ThrowIfNull(descriptor);
+
+            return PluginPageDescriptor.GetItemViewModel(provider, descriptor);
+        }
+    }
 
     /// <summary>
     /// Interface for plugins that provide settings or configuration pages.

--- a/PlugHub.Shared/Models/AppConfig.cs
+++ b/PlugHub.Shared/Models/AppConfig.cs
@@ -116,5 +116,16 @@ namespace PlugHub.Shared.Models
             = Path.Combine(AppContext.BaseDirectory, "Plugins");
 
         #endregion
+
+        #region AppConfig: Main View
+
+        /// <summary>
+        /// Gets or sets the identifier of the main view to load at startup.
+        /// This should match the composite key of a plugin-provided main view
+        /// (e.g., "Namespace.ViewType:Key"). If not set, the default main view is used.
+        /// </summary>
+        public string? MainViewKey { get; set; }
+
+        #endregion
     }
 }

--- a/PlugHub.Shared/Models/AppEnv.cs
+++ b/PlugHub.Shared/Models/AppEnv.cs
@@ -1,10 +1,31 @@
 namespace PlugHub.Shared.Models
 {
+    /// <summary>
+    /// Defines environment-specific settings for the PlugHub application.
+    /// These values typically vary by deployment environment (e.g., dev, test, prod)
+    /// and can override or complement values in <see cref="AppConfig"/>.
+    /// </summary>
     public sealed class AppEnv
     {
+        #region AppEnv: Application Identity
+
         /// <summary>
         /// Gets or sets the display name of the application.
+        /// Defaults to "PlugHub" if not specified.
         /// </summary>
-        public string? AppName { get; set; } = "PlugHub";
+        public string AppName { get; set; } = "PlugHub";
+
+        #endregion
+
+        #region AppEnv: Main View
+
+        /// <summary>
+        /// Gets or sets the identifier of the main view to load at startup.
+        /// This should match the composite key of a plugin-provided main view
+        /// (e.g., "Namespace.ViewType:Key"). If not set, the default main view is used.
+        /// </summary>
+        public string? MainViewKey { get; set; }
+
+        #endregion
     }
 }

--- a/PlugHub/ViewModels/MainViewModel.cs
+++ b/PlugHub/ViewModels/MainViewModel.cs
@@ -1,15 +1,24 @@
-﻿using Avalonia.Controls;
+﻿using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Media;
+using Avalonia.Media.Imaging;
+using Avalonia.Platform;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Microsoft.Extensions.Logging;
+using PlugHub.Shared.Interfaces.Accessors;
 using PlugHub.Shared.Interfaces.Events;
+using PlugHub.Shared.Interfaces.Plugins;
+using PlugHub.Shared.Interfaces.Services.Configuration;
+using PlugHub.Shared.Interfaces.Services.Plugins;
+using PlugHub.Shared.Models;
 using PlugHub.Shared.ViewModels;
 using PlugHub.ViewModels.Pages;
 using PlugHub.Views;
 using System;
-using System.Collections.ObjectModel;
+using System.Collections.Generic;
 using System.Diagnostics;
-
 
 namespace PlugHub.ViewModels
 {
@@ -18,74 +27,133 @@ namespace PlugHub.ViewModels
         public event EventHandler<PageNavigationChangedEventArgs>? PageNavigationChanged;
 
         private readonly ILogger<MainViewModel> logger;
+        private readonly IConfigService configService;
+        private readonly IServiceProvider serviceProvider;
+
+        private readonly ContentItemViewModel? mainPage;
         private readonly ContentItemViewModel? settingsPage;
 
+        [ObservableProperty] private string appName = "PlugHub";
+        [ObservableProperty] private IImage? appIcon = null;
+        [ObservableProperty] private string appLink = string.Empty;
 
-        [ObservableProperty]
-        private bool isPaneOpen = false;
+        [ObservableProperty] private Control? selectedMainPageContent;
 
-        [ObservableProperty]
-        private bool isModalOverlayVisible = false;
+        [ObservableProperty] private bool isMaximizeVisible = true;
+        [ObservableProperty] private bool isRestoreVisible = false;
+        [ObservableProperty] private bool isSettingsVisible = true;
+        [ObservableProperty] private bool isHomeVisible = false;
 
-        [ObservableProperty]
-        private ContentItemViewModel? selectedMainPageItem;
+        [ObservableProperty] private WindowIcon? windowIcon = null;
+        [ObservableProperty] private string? windowTitle = null;
+        [ObservableProperty] private int windowMinWidth = 0;
+        [ObservableProperty] private int windowMinHeight = 0;
 
-        [ObservableProperty]
-        private Control? selectedMainPageContent;
-
-        [ObservableProperty]
-        private ObservableCollection<ContentItemViewModel> mainPageItems;
-
-
-        public MainViewModel(ILogger<MainViewModel> logger, SettingsView settingsView, SettingsViewModel settingsViewModel)
+        public MainViewModel(ILogger<MainViewModel> logger, IServiceProvider serviceProvider, IConfigService configService, SettingsView settingsView, SettingsViewModel settingsViewModel, IEnumerable<IPluginPages> pages, IPluginResolver resolver)
         {
             this.logger = logger;
+            this.configService = configService;
+            this.serviceProvider = serviceProvider;
+
+            IConfigAccessorFor<AppEnv> appEnv = configService.GetAccessor<AppEnv>();
+
+            this.AppIcon = new Bitmap(AssetLoader.Open(new Uri("avares://PlugHub/Assets/avalonia-logo.ico")));
+            this.AppName = appEnv.Get().AppName;
+            this.AppLink = "https://enterlucent.com";
+
+            this.WindowIcon = new WindowIcon(AssetLoader.Open(new Uri("avares://PlugHub/Assets/avalonia-logo.ico")));
+            this.WindowTitle = this.AppName;
+            this.WindowMinWidth = 640;
+            this.WindowMinHeight = 480;
+
             this.settingsPage = new(typeof(SettingsView), typeof(SettingsViewModel), "", "")
             {
                 Control = settingsView,
                 ViewModel = settingsViewModel
             };
-            this.mainPageItems = [];
 
-            if (this.MainPageItems.Count > 0)
-                this.OnSelectedMainMenuViewModelChanged(this.MainPageItems[0]);
+            IReadOnlyList<PluginPageDescriptor> descriptors =
+                resolver.ResolveAndOrder<IPluginPages, PluginPageDescriptor>(pages);
+
+            if (descriptors.Count > 0)
+            {
+                this.mainPage = PluginPageDescriptor.GetItemViewModel(serviceProvider, descriptors[0]);
+
+                this.selectedMainPageContent = this.mainPage?.Control;
+            }
+
+            if (Application.Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop && desktop.MainWindow is Window w)
+                this.OnWindowStateChanged(w.WindowState);
         }
 
-        public void AddMainPageItem(ContentItemViewModel mainPageItem)
+        private void OnWindowStateChanged(WindowState state)
         {
-            this.MainPageItems.Add(mainPageItem);
-
-            if (this.MainPageItems.Count == 1)
-                this.OnSelectedMainMenuViewModelChanged(this.MainPageItems[0]);
-        }
-
-        public void OnSelectedMainMenuViewModelChanged(ContentItemViewModel? mainPageItem)
-        {
-            if (mainPageItem == null) return;
-
-            ContentItemViewModel? previousPageItem = this.SelectedMainPageItem;
-
-            this.SelectedMainPageContent = mainPageItem.Control ?? new TextBlock { Text = "Unable to find content" };
-            this.SelectedMainPageItem = mainPageItem;
-
-            PageNavigationChanged?.Invoke(this, new PageNavigationChangedEventArgs(previousPageItem, mainPageItem));
-        }
-        public void OnSelectedSettingsViewModelChanged()
-        {
-            this.SelectedMainPageContent = this.settingsPage?.Control ?? new TextBlock { Text = "Unable to find content" };
+            this.IsMaximizeVisible = state != WindowState.Maximized;
+            this.IsRestoreVisible = state == WindowState.Maximized;
         }
 
         [RelayCommand]
-        private static void AppIconClicked()
+        private void AppIconClicked()
         {
-            //TODO: Get from Branding AppConfig
-            string url = "https://enterlucent.com";
-
             Process.Start(new ProcessStartInfo
             {
-                FileName = url,
+                FileName = this.AppLink,
                 UseShellExecute = true
             });
+        }
+        [RelayCommand]
+        private void Minimize()
+        {
+            if (Application.Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop && desktop.MainWindow is Window w)
+            {
+                w.WindowState = WindowState.Minimized;
+
+                this.OnWindowStateChanged(w.WindowState);
+            }
+        }
+        [RelayCommand]
+        private void MaximizeRestore()
+        {
+            if (Application.Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop && desktop.MainWindow is Window w)
+            {
+                w.WindowState = w.WindowState == WindowState.Maximized
+                    ? WindowState.Normal
+                    : WindowState.Maximized;
+
+                this.OnWindowStateChanged(w.WindowState);
+            }
+        }
+        [RelayCommand]
+        private static void Close()
+        {
+            if (Application.Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
+                if (desktop.MainWindow is Window w)
+                    w.Close();
+        }
+
+        [RelayCommand]
+        private void GoHome()
+        {
+            var previous = this.IsHomeVisible ? this.mainPage : this.settingsPage;
+            var next = this.mainPage;
+
+            this.IsSettingsVisible = true;
+            this.IsHomeVisible = false;
+
+            this.SelectedMainPageContent = next?.Control;
+            this.PageNavigationChanged?.Invoke(this, new PageNavigationChangedEventArgs(previous, next));
+        }
+        [RelayCommand]
+        private void OpenSettings()
+        {
+            var previous = this.IsHomeVisible ? this.mainPage : this.settingsPage;
+            var next = this.settingsPage;
+
+            this.IsSettingsVisible = false;
+            this.IsHomeVisible = true;
+
+            this.SelectedMainPageContent = next?.Control;
+            this.PageNavigationChanged?.Invoke(this, new PageNavigationChangedEventArgs(previous, next));
         }
     }
 }

--- a/PlugHub/Views/MainView.axaml
+++ b/PlugHub/Views/MainView.axaml
@@ -2,59 +2,161 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:v="using:PlugHub.Views"
              xmlns:vm="using:PlugHub.ViewModels"
-             xmlns:ui="clr-namespace:FluentAvalonia.UI.Controls;assembly=FluentAvalonia"
-             
-             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
-             
+             mc:Ignorable="d"
+             d:DesignWidth="800"
+             d:DesignHeight="600"
              x:Class="PlugHub.Views.MainView"
              x:DataType="vm:MainViewModel">
-  <Grid>
-    <Grid.RowDefinitions>
-      <RowDefinition Height="32" />
-      <RowDefinition Height="*" />
-    </Grid.RowDefinitions>
 
-    <Border VerticalAlignment="Top" Name="HeaderBorder">
-      <StackPanel Grid.Column="0" Orientation="Horizontal" Margin="16 8 0 0">
-        <Button Background="Transparent" BorderBrush="Transparent" BorderThickness="0" Command="{Binding AppIconClickedCommand}" Padding="0" Margin="0 2 0 0">
-          <Image Source="avares://PlugHub/Assets/avalonia-logo.ico" Width="16" Height="16"/>
-        </Button>
-      </StackPanel>
-    </Border>
+	<UserControl.Resources>
+		<ResourceDictionary>
+			<ResourceDictionary.ThemeDictionaries>
+				<!-- Dark -->
+				<ResourceDictionary x:Key="Dark">
+					<SolidColorBrush x:Key="CloseHoverBrush" Color="#9A101A"/>
+					<SolidColorBrush x:Key="ClosePressedBrush" Color="#700A12"/>
+				</ResourceDictionary>
 
-    <!-- NavigationView -->
-    <ui:NavigationView Grid.Row="1"
-                       IsPaneOpen="{Binding IsPaneOpen}"
-                       MenuItemsSource="{Binding MainPageItems}"
-                       SelectedItem="{Binding SelectedMainPageItem}"
-                       SelectionChanged="OnNavigationView_SelectionChanged">
-      <ui:NavigationView.Resources>
-        <DataTemplate x:Key="MainPageItemTemplate">
-          <ui:NavigationViewItem Content="{Binding Label}">
-            <ui:NavigationViewItem.IconSource>
-              <ui:PathIconSource Data="{Binding Icon}"/>
-            </ui:NavigationViewItem.IconSource>
-          </ui:NavigationViewItem>
-        </DataTemplate>
-      </ui:NavigationView.Resources>
+				<!-- Light -->
+				<ResourceDictionary x:Key="Light">
+					<SolidColorBrush x:Key="CloseHoverBrush" Color="#E81123"/>
+					<SolidColorBrush x:Key="ClosePressedBrush" Color="#C50F1F"/>
+				</ResourceDictionary>
+			</ResourceDictionary.ThemeDictionaries>
+		</ResourceDictionary>
+	</UserControl.Resources>
 
-      <ui:NavigationView.MenuItemTemplate>
-        <StaticResource ResourceKey="MainPageItemTemplate"/>
-      </ui:NavigationView.MenuItemTemplate>
+	<UserControl.Styles>
 
-      <ui:NavigationView.Content>
-        <Border CornerRadius="16 0 0 0">
-          <TransitioningContentControl Content="{Binding SelectedMainPageContent}"/>
-        </Border>
-      </ui:NavigationView.Content>
-    </ui:NavigationView>
+		<!-- Base style -->
+		<Style Selector="Button.MyCaption">
+			<Setter Property="Background" Value="Transparent"/>
+			<Setter Property="BorderBrush" Value="Transparent"/>
+			<Setter Property="Foreground" Value="White"/>
+			<Setter Property="Width" Value="48"/>
+			<Setter Property="Height" Value="32"/>
+			<Setter Property="HorizontalContentAlignment" Value="Center"/>
+			<Setter Property="VerticalContentAlignment" Value="Center"/>
+		</Style>
+	</UserControl.Styles>
 
-    <Border x:Name="ModalOverlay"
-            Grid.RowSpan="2"
-            Background="#80000000"
-            IsHitTestVisible="{Binding IsModalOverlayVisible}"
-            IsVisible="{Binding IsModalOverlayVisible}" />
-  </Grid>
+	<Grid>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="32"/>
+			<RowDefinition Height="*"/>
+		</Grid.RowDefinitions>
+
+		<!-- Custom Title Bar -->
+		<Border Grid.Row="0"
+				Background="Transparent"
+				Name="HeaderBorder"
+				PointerPressed="HeaderBorder_OnPointerPressed">
+
+			<DockPanel LastChildFill="True">
+
+				<!-- Left: icon + title -->
+				<StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+					<Button Command="{Binding AppIconClickedCommand}"
+							Padding="0" Margin="8,0,0,0"
+							Background="Transparent" BorderThickness="0"
+							VerticalAlignment="Center">
+						<Image Source="{Binding AppIcon}"
+							   Width="16" Height="16"
+							   VerticalAlignment="Center"
+							   HorizontalAlignment="Center"/>
+					</Button>
+					<TextBlock Text="{Binding AppName}"
+							   FontSize="16"
+							   Margin="8,0,8,0"
+							   VerticalAlignment="Center"/>
+				</StackPanel>
+
+				<!-- Right: caption buttons -->
+				<StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+
+					<!-- Settings -->
+					<Button Classes="MyCaption"
+							Command="{Binding OpenSettingsCommand}"
+							Margin="0,0,8,0"
+							ToolTip.Tip="Open Settings"
+							IsVisible="{Binding IsSettingsVisible}">
+						<Path Width="12" Height="12"
+							  Data="M12 7.9V6.5L10.6 5.8L10.1 4.3L11 3.4L9.8 2.2L8.9 3.1L7.4 2.6L6.7 1.2H5.3L4.6 2.6L3.1 3.1L2.2 2.2L1 3.4L1.9 4.3L1.4 5.8L0 6.5V7.9L1.4 8.6L1.9 10.1L1 11L2.2 12.2L3.1 11.3L4.6 11.8L5.3 13.2H6.7L7.4 11.8L8.9 11.3L9.8 12.2L11 11L10.1 10.1L10.6 8.6L12 7.9ZM6 9.6C4.7 9.6 3.6 8.5 3.6 7.2C3.6 5.9 4.7 4.8 6 4.8C7.3 4.8 8.4 5.9 8.4 7.2C8.4 8.5 7.3 9.6 6 9.6Z"
+							  Stroke="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Button}}"
+							  StrokeThickness="1"/>
+					</Button>
+
+					<!-- Home -->
+					<Button Classes="MyCaption"
+							Command="{Binding GoHomeCommand}"
+							Margin="0,0,8,0"
+							ToolTip.Tip="Return Home"
+							IsVisible="{Binding IsHomeVisible}">
+						<Path Width="12" Height="12"
+							  Data="M0 8 L6 2 L12 8 V14 H7 V10 H5 V14 H0 Z"
+							  Stroke="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Button}}"
+							  StrokeThickness="1"/>
+					</Button>
+
+					<!-- Minimize -->
+					<Button Classes="MyCaption"
+							Command="{Binding MinimizeCommand}">
+						<Rectangle Width="10" Height="2"
+								   Fill="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Button}}"
+								   HorizontalAlignment="Center" VerticalAlignment="Center"/>
+					</Button>
+
+					<!-- Maximize -->
+					<Button Classes="MyCaption"
+							Command="{Binding MaximizeRestoreCommand}"
+							IsVisible="{Binding IsMaximizeVisible}">
+						<Path Width="10" Height="10"
+							  Data="M0 0 H10 V10 H0 Z"
+							  Stroke="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Button}}"
+							  StrokeThickness="1.5"
+							  Stretch="Uniform"
+							  HorizontalAlignment="Center"
+							  VerticalAlignment="Center"/>
+					</Button>
+
+					<!-- Restore -->
+					<Button Classes="MyCaption"
+							Command="{Binding MaximizeRestoreCommand}"
+							IsVisible="{Binding IsRestoreVisible}">
+						<Grid Width="10" Height="10" HorizontalAlignment="Center" VerticalAlignment="Center">
+							<Path Data="M2 0 H10 V8 H2 Z"
+								  Stroke="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Button}}"
+								  StrokeThickness="1.5"/>
+							<Path Data="M0 2 H8 V10 H0 Z"
+								  Stroke="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Button}}"
+								  StrokeThickness="1.5"/>
+						</Grid>
+					</Button>
+
+					<!-- Close -->
+					<Button Classes="MyCaption"
+							Command="{Binding CloseCommand}">
+						<Path Width="10" Height="10"
+							  Data="M0 0 L10 10 M10 0 L0 10"
+							  Stroke="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Button}}"
+							  StrokeThickness="1.5"
+							  StrokeLineCap="Square"
+							  Stretch="Uniform"
+							  HorizontalAlignment="Center"
+							  VerticalAlignment="Center"/>
+					</Button>
+
+				</StackPanel>
+			</DockPanel>
+		</Border>
+
+		<Border Grid.Row="1">
+			<TransitioningContentControl
+				Content="{Binding SelectedMainPageContent}"
+				HorizontalAlignment="Stretch"
+				VerticalAlignment="Stretch"/>
+		</Border>
+
+	</Grid>
 </UserControl>

--- a/PlugHub/Views/MainView.axaml.cs
+++ b/PlugHub/Views/MainView.axaml.cs
@@ -1,21 +1,15 @@
-﻿using Avalonia.Controls;
-using FluentAvalonia.UI.Controls;
+﻿using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
 using Microsoft.Extensions.Logging;
-using PlugHub.Shared.ViewModels;
 using PlugHub.ViewModels;
 
 namespace PlugHub.Views
 {
-    /// <summary>
-    /// Represents the main view user control containing the application's primary navigation.
-    /// </summary>
     public partial class MainView : UserControl
     {
         protected readonly ILogger<MainView>? Logger;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="MainView"/> class.
-        /// </summary>
         public MainView()
         {
             this.InitializeComponent();
@@ -27,20 +21,11 @@ namespace PlugHub.Views
             this.DataContext = mainViewModel;
         }
 
-        /// <summary>
-        /// Handles selection changes in the NavigationView, updating the main or settings view model accordingly.
-        /// </summary>
-        /// <param name="sender">The source of the event (expected to be a <see cref="NavigationView"/>).</param>
-        /// <param name="e">Event data for the navigation selection change.</param>
-        private void OnNavigationView_SelectionChanged(object? sender, NavigationViewSelectionChangedEventArgs e)
+        private void HeaderBorder_OnPointerPressed(object? sender, PointerPressedEventArgs e)
         {
-            if (this.DataContext is MainViewModel vm)
-            {
-                if (e.IsSettingsSelected)
-                    vm.OnSelectedSettingsViewModelChanged();
-                else
-                    vm.OnSelectedMainMenuViewModelChanged((ContentItemViewModel)e.SelectedItem);
-            }
+            if (e.GetCurrentPoint((Visual)sender!).Properties.IsLeftButtonPressed)
+                if (TopLevel.GetTopLevel(this) is Window w)
+                    w.BeginMoveDrag(e);
         }
     }
 }

--- a/PlugHub/Views/Windows/MainWindow.axaml
+++ b/PlugHub/Views/Windows/MainWindow.axaml
@@ -3,5 +3,7 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         x:Class="PlugHub.Views.Windows.MainWindow"
-        Icon="/Assets/avalonia-logo.ico"
-        MinWidth="800" MinHeight="450"/>
+        Title="{Binding WindowTitle}"
+        Icon= "{Binding WindowIcon}"
+        MinWidth="{Binding WindowMinWidth}"
+		MinHeight="{Binding WindowMinHeight}"/>


### PR DESCRIPTION
## Description  
This change introduces a new plugin integration point `IPluginMainView` and its associated `PluginMainViewDescriptor`.  
- Plugins can now formally declare and provide their own main view implementations.  
- Added `MainViewKey` to both `AppConfig` and `AppEnv` for deterministic startup selection with runtime override.  
- Refactored `Bootstrapper` to remove hard‑wired `PluginsPages` injection and instead rely on descriptors.  
- Updated `MainViewModel` and `MainWindow` to resolve the active main view via descriptors, with fallback to the default.  
- Reimagined `IPluginPage` as a neutral descriptor contract, leaving shell plugins free to consume and render pages.  

## Related Issue  
- Resolves #119  

## Motivation and Context  
Previously, the main view was resolved directly from DI, which allowed overrides but lacked a formal contract.  
This implementation aligns with PlugHub’s descriptor‑driven plugin model, providing:  
- A consistent extension mechanism for main views.  
- Enterprise stability through `AppConfig` defaults.  
- Runtime flexibility via `AppEnv` overrides.  
- Cleaner separation of concerns by removing assumptions about navigation shells.  

## How Has This Been Tested?  
- Verified startup with no plugins: falls back to default main view.  
- Verified startup with a plugin providing a main view: descriptor correctly resolved and loaded.  
- Confirmed settings pages and other plugin descriptors continue to resolve correctly.  
- Manual UI validation on desktop (Windows, Avalonia 11).  

## Types of changes  
- [ ] Bug fix (non-breaking change which fixes an issue)  
- [x] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to change)  
- [ ] Asset change (adds or updates icons, templates, or other assets)  
- [ ] Documentation change (adds or updates documentation)  
- [ ] Plugin change (adds or updates a plugin)  

## Checklist:  
- [x] I have read the **CONTRIBUTING** document.  
- [x] My change requires a change to the core logic.  
  - [x] I have linked the project issue above.  
- [ ] My change requires a change to the assets.  
  - [ ] I have linked the asset issue above.  
- [ ] My change requires a change to the documentation.  
  - [ ] I have linked the documentation issue above.  
- [ ] My change requires a change to a plugin.  
  - [ ] I have linked the plugin issue above.  