### PR TITLE
Fixed Incorrect "No Interfaces" Display in Plugin Editor

### DIFF
--- a/PlugHub/Views/Pages/SettingsPluginsView.axaml
+++ b/PlugHub/Views/Pages/SettingsPluginsView.axaml
@@ -419,7 +419,7 @@
                             VerticalAlignment="Center"
                             HorizontalAlignment="Center"
                             IsChecked="{Binding IsEnabled}"
-                            IsEnabled="{Binding HasNoInterfaces, Converter={StaticResource BooleanNegationConverter}}"/>
+                            IsEnabled="{Binding HasNoDescriptors, Converter={StaticResource BooleanNegationConverter}}"/>
 
                 </Grid>
               </Expander.Header>
@@ -440,7 +440,7 @@
                   </Border>
 
                   <!-- Table (header + rows), visible only if interfaces exist -->
-                  <StackPanel IsVisible="{Binding HasNoInterfaces, Converter={StaticResource BooleanNegationConverter}}">
+                  <StackPanel IsVisible="{Binding HasNoDescriptors, Converter={StaticResource BooleanNegationConverter}}">
                     <Border BorderThickness="1,0,1,1"
                             Padding="8"
                             Background="{DynamicResource ControlAltFillColorSecondaryBrush}">
@@ -494,7 +494,7 @@
                   <Border Classes="interface-row"
                           BorderThickness="0,0,0,1"
                           Padding="8"
-                          IsVisible="{Binding HasNoInterfaces}">
+                          IsVisible="{Binding HasNoDescriptors}">
 
                     <TextBlock Text="No interfaces provided"
                                FontStyle="Italic"


### PR DESCRIPTION
## Description  
This change corrects the property bindings in `SettingsPluginsView.axaml` that previously referenced `HasNoInterfaces`.  
The correct property is `HasNoDescriptors`, which properly reflects whether a plugin has any descriptors defined.  
By updating the bindings, the "No Interfaces" message is now only shown when appropriate, preventing misleading UI states.  

## Related Issue  
- Resolves #127  

## Motivation and Context  
The bug caused the "No Interfaces" box to appear for all plugins, even those with valid interfaces.  
This fix ensures the UI accurately reflects plugin state, improving clarity and preventing user confusion.  

## How Has This Been Tested?  
- Verified in the plugin editor that plugins with valid interfaces now correctly display their interface table.  
- Confirmed that the "No Interfaces" message only appears when a plugin truly has no descriptors.  
- Tested across multiple plugins to ensure consistent behavior.  

## Screenshots (if appropriate):  
N/A  

## Types of changes  
- [x] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to change)  
- [ ] Asset change (adds or updates icons, templates, or other assets)  
- [ ] Documentation change (adds or updates documentation)  
- [ ] Plugin change (adds or updates a plugin)  

## Checklist:  
- [x] I have read the **CONTRIBUTING** document.  
- [x] My change requires a change to the core logic.  
  - [x] I have linked the project issue above.  
- [ ] My change requires a change to the assets.  
  - [ ] I have linked the asset issue above.  
- [ ] My change requires a change to the documentation.  
  - [ ] I have linked the documentation issue above.  
- [ ] My change requires a change to a plugin.  
  - [ ] I have linked the plugin issue above.  