### PR TITLE
Added IPluginResourceIncludes for Avalonia Resources

### DIFF
--- a/PlugHub.Shared/Interfaces/Plugins/IPluginResourceInclusion.cs
+++ b/PlugHub.Shared/Interfaces/Plugins/IPluginResourceInclusion.cs
@@ -1,0 +1,50 @@
+﻿using Avalonia.Controls;
+using Avalonia.Styling;
+using PlugHub.Shared.Attributes;
+using PlugHub.Shared.Models.Plugins;
+
+namespace PlugHub.Shared.Interfaces.Plugins
+{
+    /// <summary>
+    /// Describes a plugin component that provides Avalonia resource dictionaries (AXAML files)
+    /// that must be loaded before the main UI initializes.
+    /// Declares all dependency and ordering relationships for conflict-free, deterministic resource loading.
+    /// </summary>
+    /// <param name="PluginID">Unique identifier for the plugin providing this descriptor.</param>
+    /// <param name="DescriptorID">Unique identifier for the descriptor.</param>
+    /// <param name="Version">Version of the descriptor.</param>
+    /// <param name="ResourceUri">URI of the AXAML resource to be loaded as a ResourceInclude.</param>
+    /// <param name="BaseUri">Base URI for resolving relative resource paths (defaults to plugin's base URI).</param>
+    /// <param name="Factory">Optional delegate that creates one or more <see cref="IStyle"/> or <see cref="IResourceProvider"/> instances at runtime.</param>
+    /// <param name="LoadBefore">Descriptors that should be applied after this one to maintain order.</param>
+    /// <param name="LoadAfter">Descriptors that should be applied before this one to maintain order.</param>
+    /// <param name="DependsOn">Descriptors that this descriptor explicitly depends on.</param>
+    /// <param name="ConflictsWith">Descriptors with which this descriptor cannot coexist.</param>
+    public record PluginResourceIncludeDescriptor(
+        Guid PluginID,
+        Guid DescriptorID,
+        string Version,
+        string? ResourceUri = null,
+        string? BaseUri = null,
+        Func<IResourceDictionary>? Factory = null,
+        IEnumerable<PluginDescriptorReference>? LoadBefore = null,
+        IEnumerable<PluginDescriptorReference>? LoadAfter = null,
+        IEnumerable<PluginDescriptorReference>? DependsOn = null,
+        IEnumerable<PluginDescriptorReference>? ConflictsWith = null
+    ) : PluginDescriptor(PluginID, DescriptorID, Version, LoadBefore, LoadAfter, DependsOn, ConflictsWith);
+
+    /// <summary>
+    /// Interface for plugins that supply Avalonia resource dictionaries.
+    /// Provides descriptors for AXAML resource files (styles, themes, control templates, etc.)
+    /// that need to be loaded during application bootstrap.
+    /// </summary>
+    [DescriptorProvider("GetResourceIncludeDescriptors", false)]
+    public interface IPluginResourceInclusion : IPlugin
+    {
+        /// <summary>
+        /// Returns a collection of descriptors defining Avalonia resource dictionaries
+        /// (AXAML files containing styles, themes, or other resources) offered by this plugin.
+        /// </summary>
+        IEnumerable<PluginResourceIncludeDescriptor> GetResourceIncludeDescriptors();
+    }
+}

--- a/PlugHub.Shared/Interfaces/Plugins/IPluginResourceInclusion.cs
+++ b/PlugHub.Shared/Interfaces/Plugins/IPluginResourceInclusion.cs
@@ -15,7 +15,7 @@ namespace PlugHub.Shared.Interfaces.Plugins
     /// <param name="Version">Version of the descriptor.</param>
     /// <param name="ResourceUri">URI of the AXAML resource to be loaded as a ResourceInclude.</param>
     /// <param name="BaseUri">Base URI for resolving relative resource paths (defaults to plugin's base URI).</param>
-    /// <param name="Factory">Optional delegate that creates one or more <see cref="IStyle"/> or <see cref="IResourceProvider"/> instances at runtime.</param>
+    /// <param name="Factory">Optional delegate that creates one or more <see cref="IResourceDictionary"/> or <see cref="IResourceProvider"/> instances at runtime.</param>
     /// <param name="LoadBefore">Descriptors that should be applied after this one to maintain order.</param>
     /// <param name="LoadAfter">Descriptors that should be applied before this one to maintain order.</param>
     /// <param name="DependsOn">Descriptors that this descriptor explicitly depends on.</param>


### PR DESCRIPTION
## Description
This PR introduces the new `IPluginResourceInclusion` interface, allowing plugins to contribute resource dictionaries either via URI or factory.  

The theme configuration pipeline has been updated to resolve and order these inclusions, merge them into the application’s resources, and ensure deduplication.  

This mirrors the existing `IPluginStyleInclusion` pattern, providing a consistent extension point for both resources and styles.

## Related Issue
- Resolves #135

## Motivation and Context
Previously, plugins could only contribute styles. With this change, plugins can now also provide resource dictionaries (e.g., brushes, templates, localized strings) in a structured and ordered way.  

This improves modularity, makes theming more flexible, and allows plugin authors to extend the application’s look and feel without modifying core resources.

## How Has This Been Tested?
- Verified that application resources load correctly when no plugins are present.  
- Ran existing unit and integration tests to ensure no regressions.  

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)  
- [x] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to change)  
- [ ] Asset change (adds or updates icons, templates, or other assets)  
- [ ] Documentation change (adds or updates documentation)  
- [ ] Plugin change (adds or updates a plugin)  

## Checklist:
- [x] I have read the **CONTRIBUTING** document.  
- [x] My change requires a change to the core logic.  
  - [x] I have linked the project issue above.  
- [ ] My change requires a change to the assets.  
  - [ ] I have linked the asset issue above.  
- [ ] My change requires a change to the documentation.  
  - [ ] I have linked the documentation issue above.  
- [ ] My change requires a change to a plugin.  
  - [ ] I have linked the plugin issue above.  